### PR TITLE
Drop redundant constraints, add cabal.project

### DIFF
--- a/Control/Applicative/Lift.hs
+++ b/Control/Applicative/Lift.hs
@@ -36,7 +36,6 @@ import Data.Functor.Classes
 import Control.Applicative
 import Data.Functor.Constant
 import Data.Foldable (Foldable(foldMap))
-import Data.Monoid (Monoid(..))
 import Data.Traversable (Traversable(traverse))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics

--- a/Control/Monad/Trans/Accum.hs
+++ b/Control/Monad/Trans/Accum.hs
@@ -62,7 +62,6 @@ import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.Signatures
-import Data.Monoid
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics
 #endif

--- a/Control/Monad/Trans/Accum.hs
+++ b/Control/Monad/Trans/Accum.hs
@@ -182,7 +182,7 @@ instance (Functor m) => Functor (AccumT w m) where
     fmap f = mapAccumT $ fmap $ \ ~(a, w) -> (f a, w)
     {-# INLINE fmap #-}
 
-instance (Monoid w, Functor m, Monad m) => Applicative (AccumT w m) where
+instance (Monoid w, Monad m) => Applicative (AccumT w m) where
     pure a  = AccumT $ const $ return (a, mempty)
     {-# INLINE pure #-}
     mf <*> mv = AccumT $ \ w -> do
@@ -191,13 +191,13 @@ instance (Monoid w, Functor m, Monad m) => Applicative (AccumT w m) where
       return (f v, w' `mappend` w'')
     {-# INLINE (<*>) #-}
 
-instance (Monoid w, Functor m, MonadPlus m) => Alternative (AccumT w m) where
+instance (Monoid w, MonadPlus m) => Alternative (AccumT w m) where
     empty   = AccumT $ const mzero
     {-# INLINE empty #-}
     m <|> n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
     {-# INLINE (<|>) #-}
 
-instance (Monoid w, Functor m, Monad m) => Monad (AccumT w m) where
+instance (Monoid w, Monad m) => Monad (AccumT w m) where
     m >>= k  = AccumT $ \ w -> do
         ~(a, w')  <- runAccumT m w
         ~(b, w'') <- runAccumT (k a) (w `mappend` w')
@@ -208,13 +208,13 @@ instance (Monoid w, Fail.MonadFail m) => Fail.MonadFail (AccumT w m) where
     fail msg = AccumT $ const (Fail.fail msg)
     {-# INLINE fail #-}
 
-instance (Monoid w, Functor m, MonadPlus m) => MonadPlus (AccumT w m) where
+instance (Monoid w, MonadPlus m) => MonadPlus (AccumT w m) where
     mzero       = AccumT $ const mzero
     {-# INLINE mzero #-}
     m `mplus` n = AccumT $ \ w -> runAccumT m w `mplus` runAccumT n w
     {-# INLINE mplus #-}
 
-instance (Monoid w, Functor m, MonadFix m) => MonadFix (AccumT w m) where
+instance (Monoid w, MonadFix m) => MonadFix (AccumT w m) where
     mfix m = AccumT $ \ w -> mfix $ \ ~(a, _) -> runAccumT (m a) w
     {-# INLINE mfix #-}
 
@@ -224,7 +224,7 @@ instance (Monoid w) => MonadTrans (AccumT w) where
         return (a, mempty)
     {-# INLINE lift #-}
 
-instance (Monoid w, Functor m, MonadIO m) => MonadIO (AccumT w m) where
+instance (Monoid w, MonadIO m) => MonadIO (AccumT w m) where
     liftIO = lift . liftIO
     {-# INLINE liftIO #-}
 

--- a/Control/Monad/Trans/Accum.hs
+++ b/Control/Monad/Trans/Accum.hs
@@ -106,7 +106,7 @@ execAccum m w = snd (runAccum m w)
 -- and return the final value, discarding the final output.
 --
 -- * @'evalAccum' m w = 'fst' ('runAccum' m w)@
-evalAccum :: (Monoid w) => Accum w a -> w -> a
+evalAccum :: Accum w a -> w -> a
 evalAccum m w = fst (runAccum m w)
 {-# INLINE evalAccum #-}
 
@@ -164,7 +164,7 @@ execAccumT m w = do
 -- history and return the final value, discarding the final output.
 --
 -- * @'evalAccumT' m w = 'liftM' 'fst' ('runAccumT' m w)@
-evalAccumT :: (Monad m, Monoid w) => AccumT w m a -> w -> m a
+evalAccumT :: (Monad m) => AccumT w m a -> w -> m a
 evalAccumT m w = do
     ~(a, _) <- runAccumT m w
     return a

--- a/Control/Monad/Trans/Cont.hs
+++ b/Control/Monad/Trans/Cont.hs
@@ -46,7 +46,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Functor.Identity
 
-import Control.Applicative
 import qualified Control.Monad.Fail as Fail
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics

--- a/Control/Monad/Trans/Except.hs
+++ b/Control/Monad/Trans/Except.hs
@@ -60,7 +60,6 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.Zip (MonadZip(mzipWith))
 import Data.Foldable (Foldable(foldMap))
-import Data.Monoid (Monoid(mempty, mappend))
 import Data.Traversable (Traversable(traverse))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics

--- a/Control/Monad/Trans/Except.hs
+++ b/Control/Monad/Trans/Except.hs
@@ -183,7 +183,7 @@ instance (Traversable f) => Traversable (ExceptT e f) where
         ExceptT <$> traverse (either (pure . Left) (fmap Right . f)) a
     {-# INLINE traverse #-}
 
-instance (Functor m, Monad m) => Applicative (ExceptT e m) where
+instance (Monad m) => Applicative (ExceptT e m) where
     pure a = ExceptT $ return (Right a)
     {-# INLINE pure #-}
     ExceptT f <*> ExceptT v = ExceptT $ do
@@ -199,7 +199,7 @@ instance (Functor m, Monad m) => Applicative (ExceptT e m) where
     m *> k = m >>= \_ -> k
     {-# INLINE (*>) #-}
 
-instance (Functor m, Monad m, Monoid e) => Alternative (ExceptT e m) where
+instance (Monad m, Monoid e) => Alternative (ExceptT e m) where
     empty = ExceptT $ return (Left mempty)
     {-# INLINE empty #-}
     ExceptT mx <|> ExceptT my = ExceptT $ do

--- a/Control/Monad/Trans/Maybe.hs
+++ b/Control/Monad/Trans/Maybe.hs
@@ -131,7 +131,7 @@ instance (Traversable f) => Traversable (MaybeT f) where
     traverse f (MaybeT a) = MaybeT <$> traverse (traverse f) a
     {-# INLINE traverse #-}
 
-instance (Functor m, Monad m) => Applicative (MaybeT m) where
+instance (Monad m) => Applicative (MaybeT m) where
     pure = MaybeT . return . Just
     {-# INLINE pure #-}
     mf <*> mx = MaybeT $ do
@@ -147,7 +147,7 @@ instance (Functor m, Monad m) => Applicative (MaybeT m) where
     m *> k = m >>= \_ -> k
     {-# INLINE (*>) #-}
 
-instance (Functor m, Monad m) => Alternative (MaybeT m) where
+instance (Monad m) => Alternative (MaybeT m) where
     empty = MaybeT (return Nothing)
     {-# INLINE empty #-}
     x <|> y = MaybeT $ do

--- a/Control/Monad/Trans/RWS/CPS.hs
+++ b/Control/Monad/Trans/RWS/CPS.hs
@@ -205,7 +205,7 @@ instance (Functor m) => Functor (RWST r w s m) where
     fmap f m = RWST $ \ r s w -> (\ (a, s', w') -> (f a, s', w')) <$> unRWST m r s w
     {-# INLINE fmap #-}
 
-instance (Functor m, Monad m) => Applicative (RWST r w s m) where
+instance (Monad m) => Applicative (RWST r w s m) where
     pure a = RWST $ \ _ s w -> return (a, s, w)
     {-# INLINE pure #-}
 
@@ -215,7 +215,7 @@ instance (Functor m, Monad m) => Applicative (RWST r w s m) where
         return (f x, s'', w'')
     {-# INLINE (<*>) #-}
 
-instance (Functor m, MonadPlus m) => Alternative (RWST r w s m) where
+instance (MonadPlus m) => Alternative (RWST r w s m) where
     empty = RWST $ \ _ _ _ -> mzero
     {-# INLINE empty #-}
 
@@ -233,7 +233,7 @@ instance (Fail.MonadFail m) => Fail.MonadFail (RWST r w s m) where
     fail msg = RWST $ \ _ _ _ -> Fail.fail msg
     {-# INLINE fail #-}
 
-instance (Functor m, MonadPlus m) => MonadPlus (RWST r w s m) where
+instance (MonadPlus m) => MonadPlus (RWST r w s m) where
     mzero = empty
     {-# INLINE mzero #-}
     mplus = (<|>)

--- a/Control/Monad/Trans/RWS/CPS.hs
+++ b/Control/Monad/Trans/RWS/CPS.hs
@@ -71,8 +71,6 @@ import Control.Monad.Trans.Class
 import Control.Monad.Signatures
 import Data.Functor.Identity
 
-import Data.Monoid
-
 import qualified Control.Monad.Fail as Fail
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics

--- a/Control/Monad/Trans/RWS/Lazy.hs
+++ b/Control/Monad/Trans/RWS/Lazy.hs
@@ -68,7 +68,6 @@ import Control.Applicative
 import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
-import Data.Monoid
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics
 #endif

--- a/Control/Monad/Trans/RWS/Lazy.hs
+++ b/Control/Monad/Trans/RWS/Lazy.hs
@@ -179,7 +179,7 @@ instance (Functor m) => Functor (RWST r w s m) where
         fmap (\ ~(a, s', w) -> (f a, s', w)) $ runRWST m r s
     {-# INLINE fmap #-}
 
-instance (Monoid w, Functor m, Monad m) => Applicative (RWST r w s m) where
+instance (Monoid w, Monad m) => Applicative (RWST r w s m) where
     pure a = RWST $ \ _ s -> return (a, s, mempty)
     {-# INLINE pure #-}
     RWST mf <*> RWST mx  = RWST $ \ r s -> do
@@ -188,7 +188,7 @@ instance (Monoid w, Functor m, Monad m) => Applicative (RWST r w s m) where
         return (f x, s'', w `mappend` w')
     {-# INLINE (<*>) #-}
 
-instance (Monoid w, Functor m, MonadPlus m) => Alternative (RWST r w s m) where
+instance (Monoid w, MonadPlus m) => Alternative (RWST r w s m) where
     empty = RWST $ \ _ _ -> mzero
     {-# INLINE empty #-}
     RWST m <|> RWST n = RWST $ \ r s -> m r s `mplus` n r s

--- a/Control/Monad/Trans/RWS/Strict.hs
+++ b/Control/Monad/Trans/RWS/Strict.hs
@@ -183,7 +183,7 @@ instance (Functor m) => Functor (RWST r w s m) where
         fmap (\ (a, s', w) -> (f a, s', w)) $ runRWST m r s
     {-# INLINE fmap #-}
 
-instance (Monoid w, Functor m, Monad m) => Applicative (RWST r w s m) where
+instance (Monoid w, Monad m) => Applicative (RWST r w s m) where
     pure a = RWST $ \ _ s -> return (a, s, mempty)
     {-# INLINE pure #-}
     RWST mf <*> RWST mx = RWST $ \ r s -> do
@@ -192,7 +192,7 @@ instance (Monoid w, Functor m, Monad m) => Applicative (RWST r w s m) where
         return (f x, s'', w `mappend` w')
     {-# INLINE (<*>) #-}
 
-instance (Monoid w, Functor m, MonadPlus m) => Alternative (RWST r w s m) where
+instance (Monoid w, MonadPlus m) => Alternative (RWST r w s m) where
     empty = RWST $ \ _ _ -> mzero
     {-# INLINE empty #-}
     RWST m <|> RWST n = RWST $ \ r s -> m r s `mplus` n r s

--- a/Control/Monad/Trans/RWS/Strict.hs
+++ b/Control/Monad/Trans/RWS/Strict.hs
@@ -71,7 +71,6 @@ import Control.Applicative
 import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
-import Data.Monoid
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics
 #endif

--- a/Control/Monad/Trans/Reader.hs
+++ b/Control/Monad/Trans/Reader.hs
@@ -50,7 +50,6 @@ import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.Zip (MonadZip(mzipWith))
-import Data.Functor ((<$))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics
 #endif

--- a/Control/Monad/Trans/Select.hs
+++ b/Control/Monad/Trans/Select.hs
@@ -97,7 +97,7 @@ instance (Functor m) => Functor (SelectT r m) where
     fmap f (SelectT g) = SelectT (fmap f . g . (. f))
     {-# INLINE fmap #-}
 
-instance (Functor m, Monad m) => Applicative (SelectT r m) where
+instance (Monad m) => Applicative (SelectT r m) where
     pure = lift . return
     {-# INLINE pure #-}
     SelectT gf <*> SelectT gx = SelectT $ \ k -> do
@@ -108,7 +108,7 @@ instance (Functor m, Monad m) => Applicative (SelectT r m) where
     m *> k = m >>= \_ -> k
     {-# INLINE (*>) #-}
 
-instance (Functor m, MonadPlus m) => Alternative (SelectT r m) where
+instance (MonadPlus m) => Alternative (SelectT r m) where
     empty = mzero
     {-# INLINE empty #-}
     (<|>) = mplus

--- a/Control/Monad/Trans/State/Lazy.hs
+++ b/Control/Monad/Trans/State/Lazy.hs
@@ -204,7 +204,7 @@ instance (Functor m) => Functor (StateT s m) where
         fmap (\ ~(a, s') -> (f a, s')) $ runStateT m s
     {-# INLINE fmap #-}
 
-instance (Functor m, Monad m) => Applicative (StateT s m) where
+instance (Monad m) => Applicative (StateT s m) where
     pure a = StateT $ \ s -> return (a, s)
     {-# INLINE pure #-}
     StateT mf <*> StateT mx = StateT $ \ s -> do
@@ -215,7 +215,7 @@ instance (Functor m, Monad m) => Applicative (StateT s m) where
     m *> k = m >>= \_ -> k
     {-# INLINE (*>) #-}
 
-instance (Functor m, MonadPlus m) => Alternative (StateT s m) where
+instance (MonadPlus m) => Alternative (StateT s m) where
     empty = StateT $ \ _ -> mzero
     {-# INLINE empty #-}
     StateT m <|> StateT n = StateT $ \ s -> m s `mplus` n s

--- a/Control/Monad/Trans/State/Strict.hs
+++ b/Control/Monad/Trans/State/Strict.hs
@@ -197,7 +197,7 @@ instance (Functor m) => Functor (StateT s m) where
         fmap (\ (a, s') -> (f a, s')) $ runStateT m s
     {-# INLINE fmap #-}
 
-instance (Functor m, Monad m) => Applicative (StateT s m) where
+instance (Monad m) => Applicative (StateT s m) where
     pure a = StateT $ \ s -> return (a, s)
     {-# INLINE pure #-}
     StateT mf <*> StateT mx = StateT $ \ s -> do
@@ -208,7 +208,7 @@ instance (Functor m, Monad m) => Applicative (StateT s m) where
     m *> k = m >>= \_ -> k
     {-# INLINE (*>) #-}
 
-instance (Functor m, MonadPlus m) => Alternative (StateT s m) where
+instance (MonadPlus m) => Alternative (StateT s m) where
     empty = StateT $ \ _ -> mzero
     {-# INLINE empty #-}
     StateT m <|> StateT n = StateT $ \ s -> m s `mplus` n s

--- a/Control/Monad/Trans/Writer/CPS.hs
+++ b/Control/Monad/Trans/Writer/CPS.hs
@@ -57,8 +57,6 @@ import Control.Monad.Trans.Class
 import Control.Monad.Signatures
 import Data.Functor.Identity
 
-import Data.Monoid
-
 import qualified Control.Monad.Fail as Fail
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics

--- a/Control/Monad/Trans/Writer/CPS.hs
+++ b/Control/Monad/Trans/Writer/CPS.hs
@@ -160,7 +160,7 @@ instance (Functor m) => Functor (WriterT w m) where
     fmap f m = WriterT $ \ w -> (\ (a, w') -> (f a, w')) <$> unWriterT m w
     {-# INLINE fmap #-}
 
-instance (Functor m, Monad m) => Applicative (WriterT w m) where
+instance (Monad m) => Applicative (WriterT w m) where
     pure a = WriterT $ \ w -> return (a, w)
     {-# INLINE pure #-}
 
@@ -170,7 +170,7 @@ instance (Functor m, Monad m) => Applicative (WriterT w m) where
         return (f x, w'')
     {-# INLINE (<*>) #-}
 
-instance (Functor m, MonadPlus m) => Alternative (WriterT w m) where
+instance (MonadPlus m) => Alternative (WriterT w m) where
     empty = WriterT $ const mzero
     {-# INLINE empty #-}
 
@@ -188,7 +188,7 @@ instance (Fail.MonadFail m) => Fail.MonadFail (WriterT w m) where
     fail msg = WriterT $ \ _ -> Fail.fail msg
     {-# INLINE fail #-}
 
-instance (Functor m, MonadPlus m) => MonadPlus (WriterT w m) where
+instance (MonadPlus m) => MonadPlus (WriterT w m) where
     mzero = empty
     {-# INLINE mzero #-}
     mplus = (<|>)

--- a/Control/Monad/Trans/Writer/Lazy.hs
+++ b/Control/Monad/Trans/Writer/Lazy.hs
@@ -58,7 +58,6 @@ import Control.Monad.Fix
 import Control.Monad.Signatures
 import Control.Monad.Zip (MonadZip(mzipWith))
 import Data.Foldable
-import Data.Monoid
 import Data.Traversable (Traversable(traverse))
 import Prelude hiding (null, length)
 #ifdef __GLASGOW_HASKELL__

--- a/Control/Monad/Trans/Writer/Strict.hs
+++ b/Control/Monad/Trans/Writer/Strict.hs
@@ -61,7 +61,6 @@ import Control.Monad.Fix
 import Control.Monad.Signatures
 import Control.Monad.Zip (MonadZip(mzipWith))
 import Data.Foldable
-import Data.Monoid
 import Data.Traversable (Traversable(traverse))
 import Prelude hiding (null, length)
 #ifdef __GLASGOW_HASKELL__

--- a/Data/Functor/Constant.hs
+++ b/Data/Functor/Constant.hs
@@ -27,10 +27,7 @@ import Data.Functor.Contravariant
 
 import Control.Applicative
 import Data.Foldable
-import Data.Monoid (Monoid(..))
-import Data.Traversable (Traversable(traverse))
 import Data.Bifunctor (Bifunctor(..))
-import Data.Semigroup (Semigroup((<>)))
 import Data.Bifoldable (Bifoldable(..))
 import Data.Bitraversable (Bitraversable(..))
 import Prelude hiding (null, length)

--- a/Data/Functor/Reverse.hs
+++ b/Data/Functor/Reverse.hs
@@ -33,7 +33,7 @@ import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Data.Foldable
 import Data.Traversable (Traversable(traverse))
-import Data.Monoid
+import Data.Monoid (Dual (..))
 #ifdef __GLASGOW_HASKELL__
 import GHC.Generics
 #endif

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+
+packages: .
+
+program-options
+  ghc-options:
+    -Wall -Wredundant-constraints -Werror

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 
 program-options
   ghc-options:
-    -Wall -Wredundant-constraints -Werror
+    -Wall -Wredundant-constraints -Werror -Wwarn=unused-imports

--- a/transformers.cabal
+++ b/transformers.cabal
@@ -1,50 +1,52 @@
-name:         transformers
-version:      0.6.3.0
-license:      BSD3
+name: transformers
+version: 0.6.3.0
+license: BSD3
 license-file: LICENSE
-author:       Andy Gill, Ross Paterson
-maintainer:   Ross Paterson <R.Paterson@city.ac.uk>, Steven Shuck <stevenjshuck@gmail.com>, Benjamin McRae <b.mcrae@outlook.com>
-bug-reports:  https://github.com/haskell/transformers/issues
-category:     Control
-synopsis:     Concrete functor and monad transformers
+author: Andy Gill, Ross Paterson
+maintainer: Ross Paterson <R.Paterson@city.ac.uk>, Steven Shuck <stevenjshuck@gmail.com>, Benjamin McRae <b.mcrae@outlook.com>
+bug-reports: https://github.com/haskell/transformers/issues
+category: Control
+synopsis: Concrete functor and monad transformers
 description:
-    A portable library of functor and monad transformers, inspired by
-    the paper
-    .
-    * \"Functional Programming with Overloading and Higher-Order
-    Polymorphism\", by Mark P Jones,
-    in /Advanced School of Functional Programming/, 1995
-    (<http://web.cecs.pdx.edu/~mpj/pubs/springschool.html>).
-    .
-    This package contains:
-    .
-    * the monad transformer class (in "Control.Monad.Trans.Class")
-    .
-    * concrete functor and monad transformers, each with associated
-      operations and functions to lift operations associated with other
-      transformers.
-    .
-    The package can be used on its own in portable Haskell code, in
-    which case operations need to be manually lifted through transformer
-    stacks (see "Control.Monad.Trans.Class" for some examples).
-    Alternatively, it can be used with the non-portable monad classes in
-    the @mtl@ or @monads-tf@ packages, which automatically lift operations
-    introduced by monad transformers through other transformers.
+  A portable library of functor and monad transformers, inspired by
+  the paper
+  .
+  * \"Functional Programming with Overloading and Higher-Order
+  Polymorphism\", by Mark P Jones,
+  in /Advanced School of Functional Programming/, 1995
+  (<http://web.cecs.pdx.edu/~mpj/pubs/springschool.html>).
+  .
+  This package contains:
+  .
+  * the monad transformer class (in "Control.Monad.Trans.Class")
+  .
+  * concrete functor and monad transformers, each with associated
+  operations and functions to lift operations associated with other
+  transformers.
+  .
+  The package can be used on its own in portable Haskell code, in
+  which case operations need to be manually lifted through transformer
+  stacks (see "Control.Monad.Trans.Class" for some examples).
+  Alternatively, it can be used with the non-portable monad classes in
+  the @mtl@ or @monads-tf@ packages, which automatically lift operations
+  introduced by monad transformers through other transformers.
+
 build-type: Simple
 extra-doc-files:
-    changelog.md
-    images/bind-AccumT.svg
-    images/bind-ReaderT.svg
-    images/bind-WriterT.svg
+  changelog.md
+  images/bind-AccumT.svg
+  images/bind-ReaderT.svg
+  images/bind-WriterT.svg
+
 cabal-version: 1.18
 tested-with:
-  GHC == 9.14
-  GHC == 9.12
-  GHC == 9.10
-  GHC == 9.8
-  GHC == 9.2
-  GHC == 8.10
-  MHS == 0.15
+  ghc ==8.10
+  ghc ==9.10
+  ghc ==9.12
+  ghc ==9.14
+  ghc ==9.2
+  ghc ==9.8
+  mhs ==0.15
 
 source-repository head
   type: git
@@ -52,8 +54,9 @@ source-repository head
 
 library
   default-language: Haskell2010
-  build-depends: base >= 4.14 && < 5
+  build-depends: base >=4.14 && <5
   hs-source-dirs: .
+  -- cabal-gild: discover
   exposed-modules:
     Control.Applicative.Backwards
     Control.Applicative.Lift


### PR DESCRIPTION
Using the cabal.project two redundant constraints were identified.

The warnings showing up in the review is annoying to the point that I might disable the unused imports warnings.