### PR TITLE
[TEST] Step 1: setup transformers-test package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cabal build
 
       - name: Test
-        run: cabal test
+        run: cabal test all
 
   mhs:
     runs-on: ubuntu-latest

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,7 @@
 
-packages: .
+packages:
+  .
+  test
 
 program-options
   ghc-options:

--- a/test/ComposeT.hs
+++ b/test/ComposeT.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeOperators #-}
 
-module Main (main) where
+module ComposeT (test) where
 
 import Data.Functor.Identity
 import Control.Monad
@@ -17,8 +17,8 @@ checkNonNeg = ComposeT $ do
     count <- lift get
     when (count < 0) $ throwE $ "count is negative (" ++ show count ++ ")"
 
-main :: IO ()
-main = do
+test :: IO ()
+test = do
     let negateAndCheck = lift (modify negate) >> runComposeT checkNonNeg
         unitOrE = runIdentity $ evalStateT (runExceptT negateAndCheck) (-10)
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import qualified ComposeT
+
+main :: IO ()
+main = do
+  ComposeT.test

--- a/test/transformers-test.cabal
+++ b/test/transformers-test.cabal
@@ -1,0 +1,62 @@
+name: transformers-test
+version: 0
+description: 
+  Test package for the transformers library.
+  Since test frameworks and tools also depend on transformers,
+  the test needs to be a separate package from the library
+  in order to avoid cyclic dependencies.
+
+build-type: Simple
+
+cabal-version: 1.18
+tested-with:
+  ghc ==8.10
+  ghc ==9.10
+  ghc ==9.12
+  ghc ==9.14
+  ghc ==9.2
+  ghc ==9.8
+  mhs ==0.16
+
+-- Copy of transformers package
+library
+  default-language: Haskell2010
+  build-depends: base >=4.14 && <5
+  hs-source-dirs: ..
+  exposed-modules:
+    Control.Applicative.Backwards
+    Control.Applicative.Lift
+    Control.Monad.Signatures
+    Control.Monad.Trans.Accum
+    Control.Monad.Trans.Class
+    Control.Monad.Trans.Compose
+    Control.Monad.Trans.Cont
+    Control.Monad.Trans.Except
+    Control.Monad.Trans.Identity
+    Control.Monad.Trans.Maybe
+    Control.Monad.Trans.Reader
+    Control.Monad.Trans.RWS
+    Control.Monad.Trans.RWS.CPS
+    Control.Monad.Trans.RWS.Lazy
+    Control.Monad.Trans.RWS.Strict
+    Control.Monad.Trans.Select
+    Control.Monad.Trans.State
+    Control.Monad.Trans.State.Lazy
+    Control.Monad.Trans.State.Strict
+    Control.Monad.Trans.Writer
+    Control.Monad.Trans.Writer.CPS
+    Control.Monad.Trans.Writer.Lazy
+    Control.Monad.Trans.Writer.Strict
+    Data.Functor.Constant
+    Data.Functor.Reverse
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  hs-source-dirs: .
+  main-is: main.hs
+  default-language: Haskell2010
+  other-modules:
+    ComposeT
+  build-depends:
+    base >= 4.14 && <5,
+    transformers-test

--- a/transformers.cabal
+++ b/transformers.cabal
@@ -83,10 +83,3 @@ library
     Control.Monad.Trans.Writer.Strict
     Data.Functor.Constant
     Data.Functor.Reverse
-
-test-suite ComposeT
-  type: exitcode-stdio-1.0
-  hs-source-dirs: test
-  main-is: ComposeT.hs
-  default-language: Haskell2010
-  build-depends: base, transformers


### PR DESCRIPTION
First step for strictness tests: https://github.com/haskell/transformers/issues/123

Basic setup for testing. No changes in the actual tests. 
Changes are:
- use a separate package `transformers-test` for the tests, to avoid cyclic dependency of `transformers` when using test tools and frameworks such as `tasty`. 
- created a `main.hs` for the tests and split ComposeT test to a separate module.

We can confirm that this setup works (i.e. CI runs) from this WIP PR for Writer tests: https://github.com/ynishiza/transformers/pull/2 
Inspired by the tests for `container` for both the test setup and the actual strictness tests: https://github.com/haskell/containers/tree/master/containers-tests

Next steps: Writer (Lazy, Strict, CPS), State (Lazy, Strict), RWS (Lazy, Strict, CPS) tests.