### PR TITLE
[Test] Strictness tests for Writer

### DIFF
--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -10,7 +9,6 @@
 module Arbitrary
   ( Bot (..),
     BaseMonad (..),
-    LazyIdentity(..),
     isStrictMonad,
     F1 (..),
     F1Bot (..),
@@ -22,6 +20,7 @@ import           Control.Exception (evaluate)
 
 import           Data.Data
 import           Data.Functor.Identity (Identity (..))
+import           Data.Tuple.Solo
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
@@ -32,19 +31,8 @@ bottom = error "<bottom>"
 -- | Arbitrary (Bot a) values may be bottom.
 --
 -- Borrowed from container tests: https://github.com/haskell/containers/
-newtype Bot a = Bot { unBot :: a }
-
--- Lazy version of Identity.
--- NOTE: Solo in Data.Tuple is not available for old GHC versions.
-data LazyIdentity a = LazyIdentity { runLazyIdentity :: a }
-  deriving (Functor)
-
-instance Applicative LazyIdentity where
-  pure = LazyIdentity
-  LazyIdentity f <*> LazyIdentity x = LazyIdentity $ f x
-
-instance Monad LazyIdentity where
-  LazyIdentity a >>= k = k a
+newtype Bot a
+  = Bot { unBot :: a }
 
 data BaseMonad
   = forall m. (Typeable m, Monad m) => LazyBaseMonad (forall a. m a -> IO a)
@@ -64,7 +52,7 @@ instance Arbitrary BaseMonad where
     elements
       [ LazyBaseMonad id,                           -- IO
         StrictBaseMonad (evaluate . runIdentity),   -- Identity
-        LazyBaseMonad (evaluate . runLazyIdentity), -- LazyIdentity
+        LazyBaseMonad (evaluate . getSolo),         -- Solo
         LazyBaseMonad (\f -> evaluate $ f ())       -- constant function () -> a
       ]
 

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -12,6 +12,7 @@ module Arbitrary
     BaseMonad (..),
     isStrictMonad,
     F1 (..),
+    F1Bot(..),
     withBaseMonad,
   )
 where
@@ -90,6 +91,30 @@ newtype F1 a b = F1 {unF1 :: a -> b}
 
 instance (Typeable a, Typeable b) => Show (F1 a b) where
   show :: F1 a b -> String
+  show _ = a <> " -> " <> b
+    where
+      a = show $ typeRep (Proxy @a)
+      b = show $ typeRep (Proxy @b)
+
+-- | Arbitrary function which may bottom in the output.
+--
+-- To be precise, the function is either
+-- a) a valid arbitrary function i.e. never bottoms, or
+-- b) a constant function which always bottoms.
+--
+-- In particular, the Quickcheck builtin Func cannot be used for this, since
+-- Func a (Bot b) generates a function which may or may not bottom depending on the input.
+newtype F1Bot a b = F1Bot {unF1Bot :: a -> b}
+
+instance (CoArbitrary a, Arbitrary b) => Arbitrary (F1Bot a b) where
+  arbitrary = do
+    useBottomFunc <- arbitrary :: Gen Bool
+    if useBottomFunc
+       then return $ F1Bot $ const bottom
+       else F1Bot <$> (arbitrary :: Gen (a -> b))
+
+instance (Typeable a, Typeable b) => Show (F1Bot a b) where
+  show :: F1Bot a b -> String
   show _ = a <> " -> " <> b
     where
       a = show $ typeRep (Proxy @a)

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -12,7 +12,7 @@ module Arbitrary
     BaseMonad (..),
     isStrictMonad,
     F1 (..),
-    F1Bot(..),
+    F1Bot (..),
     withBaseMonad,
   )
 where

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -35,7 +35,7 @@ newtype Bot a = Bot { unBot :: a }
 
 -- Lazy version of Identity.
 -- NOTE: Solo in Data.Tuple is not available for old GHC versions.
-data LazyIdentity a = LazyIdentity {runLazyIdentity :: a}
+data LazyIdentity a = LazyIdentity { runLazyIdentity :: a }
   deriving (Functor)
 
 instance Applicative LazyIdentity where
@@ -61,7 +61,7 @@ isStrictMonad (StrictBaseMonad _) = True
 instance Arbitrary BaseMonad where
   arbitrary =
     elements
-      [ LazyBaseMonad id,                         -- IO
+      [ LazyBaseMonad id,                           -- IO
         StrictBaseMonad (evaluate . runIdentity),   -- Identity
         LazyBaseMonad (evaluate . runLazyIdentity), -- LazyIdentity
         LazyBaseMonad (\f -> evaluate $ f ())       -- constant function () -> a
@@ -85,8 +85,8 @@ instance Arbitrary a => Arbitrary (Bot a) where
         (4, Bot <$> arbitrary)
       ]
 
--- | Arbitrary function of 1 argument
-newtype F1 a b = F1 {unF1 :: a -> b}
+-- | Arbitrary function of one argument.
+newtype F1 a b = F1 { unF1 :: a -> b }
   deriving newtype (Arbitrary)
 
 instance (Typeable a, Typeable b) => Show (F1 a b) where
@@ -104,14 +104,15 @@ instance (Typeable a, Typeable b) => Show (F1 a b) where
 --
 -- In particular, the Quickcheck builtin Func cannot be used for this, since
 -- Func a (Bot b) generates a function which may or may not bottom depending on the input.
-newtype F1Bot a b = F1Bot {unF1Bot :: a -> b}
+newtype F1Bot a b = F1Bot { unF1Bot :: a -> b }
 
 instance (CoArbitrary a, Arbitrary b) => Arbitrary (F1Bot a b) where
   arbitrary = do
     useBottomFunc <- arbitrary :: Gen Bool
-    if useBottomFunc
-       then return $ F1Bot $ const bottom
-       else F1Bot <$> (arbitrary :: Gen (a -> b))
+    F1Bot <$>
+      if useBottomFunc
+        then return (const bottom)
+        else (arbitrary :: Gen (a -> b))
 
 instance (Typeable a, Typeable b) => Show (F1Bot a b) where
   show :: F1Bot a b -> String

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -1,17 +1,21 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Utils
-  ( Bot (..),
-    bottom,
+module Arbitrary
+  (
+    Bot(..),
+    BaseMonad(..),
     F1 (..),
   )
 where
 
 import           Data.Data
+import           Data.Functor.Identity (Identity (..))
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
@@ -23,6 +27,17 @@ bottom = error "<bottom>"
 --
 -- Borrowed from container tests: https://github.com/haskell/containers/
 newtype Bot a = Bot a
+
+data BaseMonad = forall m. Monad m => BaseMonad (forall a. m a -> IO a)
+
+identityBaseMonad:: BaseMonad
+identityBaseMonad = BaseMonad (return . runIdentity)
+
+ioBaseMonad :: BaseMonad
+ioBaseMonad = BaseMonad id
+
+instance Arbitrary BaseMonad where
+  arbitrary = elements [identityBaseMonad, ioBaseMonad]
 
 instance Show a => Show (Bot a) where
   show (Bot x) = if isBottom x then "<bottom>" else show x
@@ -44,3 +59,6 @@ instance (Typeable a, Typeable b) => Show (F1 a b) where
     where
       a = show $ typeRep (Proxy @a)
       b = show $ typeRep (Proxy @b)
+
+
+

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -16,6 +16,8 @@ module Arbitrary
   )
 where
 
+import           Control.Exception (evaluate)
+
 import           Data.Data
 import           Data.Functor.Identity (Identity (..))
 
@@ -28,7 +30,7 @@ bottom = error "<bottom>"
 -- | Arbitrary (Bot a) values may be bottom.
 --
 -- Borrowed from container tests: https://github.com/haskell/containers/
-newtype Bot a = Bot a
+newtype Bot a = Bot { unBot :: a }
 
 -- Lazy version of Identity.
 -- NOTE: Solo in Data.Tuple is not available for old GHC versions.
@@ -59,9 +61,9 @@ instance Arbitrary BaseMonad where
   arbitrary =
     elements
       [ LazyBaseMonad id,                         -- IO
-        StrictBaseMonad (return . runIdentity),   -- Identity
-        LazyBaseMonad (return . runLazyIdentity), -- LazyIdentity
-        LazyBaseMonad (\f -> return $ f ())       -- constant function () -> a
+        StrictBaseMonad (evaluate . runIdentity),   -- Identity
+        LazyBaseMonad (evaluate . runLazyIdentity), -- LazyIdentity
+        LazyBaseMonad (\f -> evaluate $ f ())       -- constant function () -> a
       ]
 
 instance Show BaseMonad where

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -10,6 +10,7 @@
 module Arbitrary
   ( Bot (..),
     BaseMonad (..),
+    LazyIdentity(..),
     isStrictMonad,
     F1 (..),
     F1Bot (..),

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -49,7 +49,7 @@ data BaseMonad
   = forall m. (Typeable m, Monad m) => LazyBaseMonad (forall a. m a -> IO a)
   | forall m. (Typeable m, Monad m) => StrictBaseMonad (forall a. m a -> IO a)
 
--- Use underlying Monad of a BaseMonad.
+-- Use the underlying Monad of a BaseMonad.
 withBaseMonad :: BaseMonad -> (forall m. (Monad m) => m a) -> IO a
 withBaseMonad (LazyBaseMonad v)   = v
 withBaseMonad (StrictBaseMonad v) = v
@@ -96,13 +96,13 @@ instance (Typeable a, Typeable b) => Show (F1 a b) where
       a = show $ typeRep (Proxy @a)
       b = show $ typeRep (Proxy @b)
 
--- | Arbitrary function which may bottom in the output.
+-- | Arbitrary function that may bottom in the output.
 --
 -- To be precise, the function is either
 -- a) a valid arbitrary function i.e. never bottoms, or
 -- b) a constant function which always bottoms.
 --
--- In particular, the Quickcheck builtin Func cannot be used for this, since
+-- In particular, the QuickCheck built-in Func cannot be used for this, since
 -- Func a (Bot b) generates a function which may or may not bottom depending on the input.
 newtype F1Bot a b = F1Bot { unF1Bot :: a -> b }
 

--- a/test/Arbitrary.hs
+++ b/test/Arbitrary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -7,10 +8,11 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Arbitrary
-  (
-    Bot(..),
-    BaseMonad(..),
+  ( Bot (..),
+    BaseMonad (..),
+    isStrictMonad,
     F1 (..),
+    withBaseMonad,
   )
 where
 
@@ -28,16 +30,47 @@ bottom = error "<bottom>"
 -- Borrowed from container tests: https://github.com/haskell/containers/
 newtype Bot a = Bot a
 
-data BaseMonad = forall m. Monad m => BaseMonad (forall a. m a -> IO a)
+-- Lazy version of Identity.
+-- NOTE: Solo in Data.Tuple is not available for old GHC versions.
+data LazyIdentity a = LazyIdentity {runLazyIdentity :: a}
+  deriving (Functor)
 
-identityBaseMonad:: BaseMonad
-identityBaseMonad = BaseMonad (return . runIdentity)
+instance Applicative LazyIdentity where
+  pure = LazyIdentity
+  LazyIdentity f <*> LazyIdentity x = LazyIdentity $ f x
 
-ioBaseMonad :: BaseMonad
-ioBaseMonad = BaseMonad id
+instance Monad LazyIdentity where
+  LazyIdentity a >>= k = k a
+
+data BaseMonad
+  = forall m. (Typeable m, Monad m) => LazyBaseMonad (forall a. m a -> IO a)
+  | forall m. (Typeable m, Monad m) => StrictBaseMonad (forall a. m a -> IO a)
+
+-- Use underlying Monad of a BaseMonad.
+withBaseMonad :: BaseMonad -> (forall m. (Monad m) => m a) -> IO a
+withBaseMonad (LazyBaseMonad v)   = v
+withBaseMonad (StrictBaseMonad v) = v
+
+isStrictMonad :: BaseMonad -> Bool
+isStrictMonad (LazyBaseMonad _)   = False
+isStrictMonad (StrictBaseMonad _) = True
 
 instance Arbitrary BaseMonad where
-  arbitrary = elements [identityBaseMonad, ioBaseMonad]
+  arbitrary =
+    elements
+      [ LazyBaseMonad id,                         -- IO
+        StrictBaseMonad (return . runIdentity),   -- Identity
+        LazyBaseMonad (return . runLazyIdentity), -- LazyIdentity
+        LazyBaseMonad (\f -> return $ f ())       -- constant function () -> a
+      ]
+
+instance Show BaseMonad where
+  show v = case v of
+    (StrictBaseMonad m) -> "StrictBaseMonad " <> getName m
+    (LazyBaseMonad m)   -> "LazyBaseMonad " <> getName m
+    where
+      getName :: forall m. (Typeable m) => (forall a. m a -> IO a) -> String
+      getName _ = show $ typeRep (Proxy @m)
 
 instance Show a => Show (Bot a) where
   show (Bot x) = if isBottom x then "<bottom>" else show x
@@ -50,7 +83,7 @@ instance Arbitrary a => Arbitrary (Bot a) where
       ]
 
 -- | Arbitrary function of 1 argument
-newtype F1 a b = F1 { unF1::a -> b }
+newtype F1 a b = F1 {unF1 :: a -> b}
   deriving newtype (Arbitrary)
 
 instance (Typeable a, Typeable b) => Show (F1 a b) where
@@ -59,6 +92,3 @@ instance (Typeable a, Typeable b) => Show (F1 a b) where
     where
       a = show $ typeRep (Proxy @a)
       b = show $ typeRep (Proxy @b)
-
-
-

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,17 +1,25 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+-- Needed since Typeable is redundant in GHC 9.14
+{-# OPTIONS_GHC -Wwarn=redundant-constraints #-}
 
 module Utils
   ( Bot (..),
+    bottom,
+    F1 (..),
+    unF1,
   )
 where
 
-import Test.ChasingBottoms (bottom)
+import Data.Data
 import Test.ChasingBottoms.IsBottom (isBottom)
 import Test.QuickCheck
 
-instance Show (String -> String) where
-  show _ = "string function"
+bottom :: forall a. a
+bottom = error "<bottom>"
 
 -- | Arbitrary (Bot a) values may be bottom.
 newtype Bot a = Bot a
@@ -25,3 +33,16 @@ instance (Arbitrary a) => Arbitrary (Bot a) where
       [ (1, pure bottom),
         (4, Bot <$> arbitrary)
       ]
+
+newtype F1 a b = F1 (a -> b)
+  deriving newtype (Arbitrary)
+
+unF1 :: F1 a b -> a -> b
+unF1 (F1 f) = f
+
+instance forall a b. (Typeable a, Typeable b) => Show (F1 a b) where
+  show :: F1 a b -> String
+  show _ = a <> " -> " <> b
+    where
+      a = show $ typeRep (Proxy @a)
+      b = show $ typeRep (Proxy @a)

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -8,7 +8,6 @@ module Utils
   ( Bot (..),
     bottom,
     F1 (..),
-    unF1,
   )
 where
 
@@ -36,13 +35,10 @@ instance Arbitrary a => Arbitrary (Bot a) where
       ]
 
 -- | Arbitrary function of 1 argument
-newtype F1 a b = F1 (a -> b)
+newtype F1 a b = F1 { unF1::a -> b }
   deriving newtype (Arbitrary)
 
-unF1 :: F1 a b -> a -> b
-unF1 (F1 f) = f
-
-instance forall a b. (Typeable a, Typeable b) => Show (F1 a b) where
+instance (Typeable a, Typeable b) => Show (F1 a b) where
   show :: F1 a b -> String
   show _ = a <> " -> " <> b
     where

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,10 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
--- Needed since Typeable is redundant in GHC 9.14
-{-# OPTIONS_GHC -Wwarn=redundant-constraints #-}
 
 module Utils
   ( Bot (..),
@@ -14,9 +13,10 @@ module Utils
   )
 where
 
-import Data.Data
-import Test.ChasingBottoms.IsBottom (isBottom)
-import Test.QuickCheck
+import           Data.Data
+
+import           Test.ChasingBottoms.IsBottom (isBottom)
+import           Test.QuickCheck
 
 bottom :: forall a. a
 bottom = error "<bottom>"
@@ -40,7 +40,12 @@ newtype F1 a b = F1 (a -> b)
 unF1 :: F1 a b -> a -> b
 unF1 (F1 f) = f
 
+#if __GLASGOW_HASKELL__ < 914
+-- Typeable is redundant in GHC 9.14
 instance forall a b. (Typeable a, Typeable b) => Show (F1 a b) where
+#else
+instance forall a b. Show (F1 a b) where
+#endif
   show :: F1 a b -> String
   show _ = a <> " -> " <> b
     where

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -22,32 +21,30 @@ bottom :: forall a. a
 bottom = error "<bottom>"
 
 -- | Arbitrary (Bot a) values may be bottom.
+--
+-- Borrowed from container tests: https://github.com/haskell/containers/
 newtype Bot a = Bot a
 
-instance (Show a) => Show (Bot a) where
+instance Show a => Show (Bot a) where
   show (Bot x) = if isBottom x then "<bottom>" else show x
 
-instance (Arbitrary a) => Arbitrary (Bot a) where
+instance Arbitrary a => Arbitrary (Bot a) where
   arbitrary =
     frequency
       [ (1, pure bottom),
         (4, Bot <$> arbitrary)
       ]
 
+-- | Arbitrary function of 1 argument
 newtype F1 a b = F1 (a -> b)
   deriving newtype (Arbitrary)
 
 unF1 :: F1 a b -> a -> b
 unF1 (F1 f) = f
 
-#if __GLASGOW_HASKELL__ < 914
--- Typeable is redundant in GHC 9.14
 instance forall a b. (Typeable a, Typeable b) => Show (F1 a b) where
-#else
-instance forall a b. Show (F1 a b) where
-#endif
   show :: F1 a b -> String
   show _ = a <> " -> " <> b
     where
       a = show $ typeRep (Proxy @a)
-      b = show $ typeRep (Proxy @a)
+      b = show $ typeRep (Proxy @b)

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Utils
+  ( Bot (..),
+  )
+where
+
+import Test.ChasingBottoms (bottom)
+import Test.ChasingBottoms.IsBottom (isBottom)
+import Test.QuickCheck
+
+instance Show (String -> String) where
+  show _ = "string function"
+
+-- | Arbitrary (Bot a) values may be bottom.
+newtype Bot a = Bot a
+
+instance (Show a) => Show (Bot a) where
+  show (Bot x) = if isBottom x then "<bottom>" else show x
+
+instance (Arbitrary a) => Arbitrary (Bot a) where
+  arbitrary =
+    frequency
+      [ (1, pure bottom),
+        (4, Bot <$> arbitrary)
+      ]

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -38,7 +38,7 @@ import           Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Utils
+import           Arbitrary
 
 test :: IO ()
 test = defaultMain $ testGroup "Writer" strictPairTests

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -20,6 +20,7 @@ import           Data.Functor.Contravariant
 import           Data.Functor.Identity
 import           Data.List (isPrefixOf)
 import           Data.Monoid
+import           Data.Tuple.Solo
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
@@ -66,11 +67,11 @@ type SumInt = Sum Int
 --
 --   x >>= k
 --
--- is strict in k. In particular, x >>= _|_ is _|_ regardless of the value of x.
+-- is strict in x if k is strict and lazy if k is lazy.
 --
 -- b) lazy as a data type.
 --
--- We employ LazyIdentity since it is a simple monad that has both properties.
+-- We employ Solo since it is a simple monad that has both properties.
 --
 -- The reasoning is as follows.
 -- The distinguishing feature of the strict writer is that it is strict in the sequencing of computations.
@@ -91,20 +92,20 @@ strictnessTest = [
       -- NOTE: Lazy and Strict are the same since there is no computational sequence involved.
       -- The output is exactly the same as the input.
       testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) ->
-        isStrictIn p $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p),
+        isStrictIn p $ getSolo $ Lazy.runWriterT $ Lazy.writer @Solo (unBotDeeper p),
       testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) ->
-        isStrictIn p $ runLazyIdentity $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p),
-      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+        isStrictIn p $ getSolo $ Strict.runWriterT $ Strict.writer @Solo (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.writer @SumInt @Solo (unBotDeeper p)
   ],
 
   testGroup "execWriterT" [
       testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) ->
-        let result = Lazy.execWriterT $ Lazy.WriterT $ LazyIdentity (unBotDeeper p)
-         in isLazy result .&. isStrictDeeperIn p (runLazyIdentity result),
+        let result = Lazy.execWriterT $ Lazy.WriterT $ MkSolo (unBotDeeper p)
+         in isLazy result .&. isStrictDeeperIn p (getSolo result),
       testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) ->
-        let result = Strict.execWriterT $ Strict.WriterT $ LazyIdentity (unBotDeeper p)
-         in isStrictIn p result .&. isStrictDeeperIn p (runLazyIdentity result),
-      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.execWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+        let result = Strict.execWriterT $ Strict.WriterT $ MkSolo (unBotDeeper p)
+         in isStrictIn p result .&. isStrictDeeperIn p (getSolo result),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.execWriterT $ CPS.writer @SumInt @Solo (unBotDeeper p)
   ],
 
   -- Lazy, Strict Writer    output of map is used directly without any intervention by the Writer itself
@@ -114,38 +115,38 @@ strictnessTest = [
       testProperty "Lazy"   $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             v = f' ((), mempty)
-            result = Lazy.runWriterT $ Lazy.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+            result = Lazy.runWriterT $ Lazy.mapWriterT @Solo (f'<$>) $ pure ()
          -- Never bottoms in the outer constructor since the result of the map is used as is.
-         in isLazy result .&. isStrictIn v (runLazyIdentity result),
+         in isLazy result .&. isStrictIn v (getSolo result),
       testProperty "Strict" $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             v = f' ((), mempty)
-            result = Strict.runWriterT $ Strict.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+            result = Strict.runWriterT $ Strict.mapWriterT @Solo (f'<$>) $ pure ()
          -- Never bottoms in the outer constructor since the result of the map is used as is.
-         in isLazy result .&. isStrictIn v (runLazyIdentity result),
+         in isLazy result .&. isStrictIn v (getSolo result),
       testProperty "CPS"    $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = coerce f :: ((), SumInt) -> ((), SumInt)
             v = f' ((), mempty)
-        in isBiStrictIn v (snd v) $ CPS.runWriterT $ CPS.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+        in isBiStrictIn v (snd v) $ CPS.runWriterT $ CPS.mapWriterT @Solo (f'<$>) $ pure ()
   ],
 
   testGroup "listen" [
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
-      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
-      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listen $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy getSolo $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ MkSolo (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ MkSolo (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listen $ CPS.writer @SumInt @Solo (unBotDeeper p)
   ],
 
   testGroup "listens" [
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
-      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
-      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listens id $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy getSolo $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ MkSolo (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ MkSolo (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listens id $ CPS.writer @SumInt @Solo (unBotDeeper p)
   ],
 
   testGroup "tell" [
       -- NOTE: Lazy and Strict here are both lazy since there is no computational sequence involved here.
-      testProperty "Lazy"   $ \(Bot (w :: SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.tell @LazyIdentity w,
-      testProperty "Strict" $ \(Bot (w :: SumInt)) -> isValueLazy runLazyIdentity $ Strict.runWriterT $ Strict.tell @LazyIdentity w,
-      testProperty "CPS"    $ \(Bot (w :: SumInt)) -> isStrictIn w $ CPS.runWriterT $ CPS.tell @SumInt @LazyIdentity w
+      testProperty "Lazy"   $ \(Bot (w :: SumInt)) -> isValueLazy getSolo $ Lazy.runWriterT $ Lazy.tell @Solo w,
+      testProperty "Strict" $ \(Bot (w :: SumInt)) -> isValueLazy getSolo $ Strict.runWriterT $ Strict.tell @Solo w,
+      testProperty "CPS"    $ \(Bot (w :: SumInt)) -> isStrictIn w $ CPS.runWriterT $ CPS.tell @SumInt @Solo w
   ],
 
   -- NOTE: strictness in the log w for censor (CPS only)
@@ -155,68 +156,68 @@ strictnessTest = [
   testGroup "censor" [
       testProperty "Lazy"   $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
-        in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ LazyIdentity p,
+        in isValueLazy getSolo $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ MkSolo p,
       testProperty "Strict" $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
-        in isStrictIn p $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ LazyIdentity p,
+        in isStrictIn p $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ MkSolo p,
       testProperty "CPS"    $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
             result = f' mempty
-        in isBiStrictIn p result $ CPS.runWriterT $ CPS.censor f' $ CPS.writer @SumInt @LazyIdentity p
+        in isBiStrictIn p result $ CPS.runWriterT $ CPS.censor f' $ CPS.writer @SumInt @Solo p
   ],
 
   -- See note on censor above.
   testGroup "pass" [
       testProperty "Lazy"   $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-        in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ LazyIdentity p',
+        in isValueLazy getSolo $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ MkSolo p',
       testProperty "Strict" $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-        in isStrictIn p $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ LazyIdentity p',
+        in isStrictIn p $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ MkSolo p',
       testProperty "CPS"    $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
             result = (snd $ fst p') mempty
-        in isBiStrictIn p result $ CPS.runWriterT $ CPS.pass $ CPS.writer @SumInt @LazyIdentity p'
+        in isBiStrictIn p result $ CPS.runWriterT $ CPS.pass $ CPS.writer @SumInt @Solo p'
   ],
 
   -- == Functor/Applicative/Monad ==
   testGroup "Functor: fmap" [
-      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (LazyIdentity (unBotDeeper p)),
+      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) -> isValueLazy getSolo $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (MkSolo (unBotDeeper p)),
       -- Never bottoms in the outer constructor since Functor only exposes control over the inner value.
-      testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ runLazyIdentity $ Strict.runWriterT $ (+1) <$> Strict.WriterT (LazyIdentity (unBotDeeper p)),
-      testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ (+1) <$> CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+      testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ getSolo $ Strict.runWriterT $ (+1) <$> Strict.WriterT (MkSolo (unBotDeeper p)),
+      testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ (+1) <$> CPS.writer @SumInt @Solo (unBotDeeper p)
     ],
 
   testGroup "Applicative: <*>" [
       testProperty "Lazy"    $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity f' <*> Lazy.writer(unBotDeeper p),
+         in isValueLazy getSolo $ Lazy.runWriterT $ Lazy.writer @Solo f' <*> Lazy.writer(unBotDeeper p),
       testProperty "Strict"  $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
           -- Never bottoms in the outer constructor since Applicative only exposes control over the inner value.
-           in isBiStrictIn p f' $ runLazyIdentity $ Strict.runWriterT $ Strict.writer @LazyIdentity f' <*> Strict.writer(unBotDeeper p),
+           in isBiStrictIn p f' $ getSolo $ Strict.runWriterT $ Strict.writer @Solo f' <*> Strict.writer(unBotDeeper p),
       testProperty "CPS"     $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isBiStrictDeeperIn p wf $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity f' <*> CPS.writer (unBotDeeper p)
+         in isBiStrictDeeperIn p wf $ CPS.runWriterT $ CPS.writer @SumInt @Solo f' <*> CPS.writer (unBotDeeper p)
     ],
 
   testGroup "Applicative: liftA2" [
       testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isValueLazy runLazyIdentity $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer @LazyIdentity $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
+          isValueLazy getSolo $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer @Solo $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
       testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
           -- Never bottoms in the outer constructor since Applicative only exposes control over the inner value.
-          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ liftA2 (+) (Strict.writer @LazyIdentity $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
+          isBiStrictIn p q $ getSolo $ Strict.runWriterT $ liftA2 (+) (Strict.writer @Solo $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
       testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isBiStrictDeeperIn p q $ CPS.runWriterT $ liftA2 (+) (CPS.writer @SumInt @LazyIdentity $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
+          isBiStrictDeeperIn p q $ CPS.runWriterT $ liftA2 (+) (CPS.writer @SumInt @Solo $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
     ],
 
   testGroup "Monad: >>=" [
       testProperty "Lazy"    $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p) >>= const (Lazy.writer $ unBotDeeper q),
+          isValueLazy getSolo $ Lazy.runWriterT $ Lazy.writer @Solo (unBotDeeper p) >>= const (Lazy.writer $ unBotDeeper q),
       testProperty "Strict"  $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isBiStrictIn p q $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p) >>= const (Strict.writer $ unBotDeeper q),
+          isBiStrictIn p q $ Strict.runWriterT $ Strict.writer @Solo (unBotDeeper p) >>= const (Strict.writer $ unBotDeeper q),
       testProperty "CPS"     $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isBiStrictDeeperIn p q $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
+          isBiStrictDeeperIn p q $ CPS.runWriterT $ CPS.writer @SumInt @Solo (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
 
 
@@ -249,11 +250,12 @@ strictnessTest = [
       testProperty "Lazy"  $
         \(Bot (p :: (Int, SumInt)))
          (Bot (q :: (Int, SumInt))) ->
-           isLazy $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
+           isValueLazy getSolo $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (MkSolo p)) (Lazy.WriterT (MkSolo q)),
       testProperty "Strict"  $
         \(Bot (p :: (Int, SumInt)))
          (Bot (q :: (Int, SumInt))) ->
-           isBiStrictIn p q $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
+           let result = Strict.runWriterT $ mzipWith (+) (Strict.WriterT (MkSolo p)) (Strict.WriterT (MkSolo q))
+            in isLazy result .&. isBiStrictIn p q (getSolo result)
       -- NOTE: no MonadZip for CPS
   ],
 

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,12 +1,16 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module WriterStrictness (test) where
 
 import           Arbitrary
 
 import           Control.Applicative
-import           Control.Exception (ErrorCall (..), evaluate)
+import           Control.Exception (ErrorCall (..))
 import           Control.Exception.Base (displayException)
+import           Control.Monad.Fix (MonadFix (..))
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
@@ -57,10 +61,17 @@ type SumInt = Sum Int
 --
 strictnessTest :: [TestTree]
 strictnessTest = [
-  testGroup "Strictness" [
-      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p),
-      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer (unBotDeeper p),
-      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p)
+  testGroup "writer" [
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
+  ],
+
+  testGroup "execWriterT" [
+      -- NOTE: TODO explain why we use LazyIdentity here
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.execWriterT $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.execWriterT $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.execWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   -- Lazy, Strict Writer    output of map is used directly without any intervention by the Writer itself
@@ -68,36 +79,36 @@ strictnessTest = [
   --
   -- CPS Writer             output of map is evaluated in the log w
   testGroup "mapWriter" [
-      testProperty "Lazy"   $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+      testProperty "Lazy"   $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             result = f' ((), mempty)
-        in isStrictIn result $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT (f'<$>) $ pure (),
-      testProperty "Strict" $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+        in isStrictIn result $ runLazyIdentity $ Lazy.runWriterT $ Lazy.mapWriterT @LazyIdentity (f'<$>) $ pure (),
+      testProperty "Strict" $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             result = f' ((), mempty)
-        in isStrictIn result $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT (f'<$>) $ pure (),
-      testProperty "CPS"    $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+        in isStrictIn result $ runLazyIdentity $ Strict.runWriterT $ Strict.mapWriterT @LazyIdentity (f'<$>) $ pure (),
+      testProperty "CPS"    $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = coerce f :: ((), SumInt) -> ((), SumInt)
             result = f' ((), mempty)
-        in isBiStrictIn result (snd result) $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT (f'<$>) $ pure ()
+        in isBiStrictIn result (snd result) $ CPS.runWriterT $ CPS.mapWriterT @LazyIdentity (f'<$>) $ pure ()
   ],
 
   testGroup "listen" [
-      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return (unBotDeeper p),
-      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return (unBotDeeper p),
-      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeeper p)
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listen $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   testGroup "listens" [
-      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ return (unBotDeeper p),
-      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ return (unBotDeeper p),
-      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeeper p)
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listens id $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   testGroup "tell" [
-      testProperty "Lazy"   $ \(m, Bot (w :: SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.tell w,
-      testProperty "Strict" $ \(m, Bot (w :: SumInt)) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.tell w,
-      testProperty "CPS"    $ \(m, Bot (w :: SumInt)) -> isStrictIn w $ withBaseMonad m $ CPS.runWriterT $ CPS.tell w
+      testProperty "Lazy"   $ \(Bot (w :: SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.tell w,
+      testProperty "Strict" $ \(Bot (w :: SumInt)) -> isLazy $ runLazyIdentity $ Strict.runWriterT $ Strict.tell w,
+      testProperty "CPS"    $ \(Bot (w :: SumInt)) -> isStrictIn w $ CPS.runWriterT $ CPS.tell @SumInt @LazyIdentity w
   ],
 
   -- NOTE: strictness in the log w for censor (CPS only)
@@ -105,67 +116,67 @@ strictnessTest = [
   -- not the initial value in the given writer.
   -- Thus, for the tests below, a bottom log value is tested in the output of the log censor f, instead of the log w in the initial (a, w).
   testGroup "censor" [
-      testProperty "Lazy"   $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+      testProperty "Lazy"   $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
-        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+        in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ LazyIdentity p,
+      testProperty "Strict" $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
-        in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+        in isStrictIn p $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ LazyIdentity p,
+      testProperty "CPS"    $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
             result = f' mempty
-        in isBiStrictIn p result $ withBaseMonad m $ CPS.runWriterT $ CPS.censor f' $ CPS.writer p
+        in isBiStrictIn p result $ CPS.runWriterT $ CPS.censor f' $ CPS.writer @SumInt @LazyIdentity p
   ],
 
   -- See note on censor above.
   testGroup "pass" [
-      testProperty "Lazy"   $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
+      testProperty "Lazy"   $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ return p',
-      testProperty "Strict" $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
+        in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ LazyIdentity p',
+      testProperty "Strict" $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-        in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ return p',
-      testProperty "CPS"    $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
+        in isStrictIn p $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ LazyIdentity p',
+      testProperty "CPS"    $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
             result = (snd $ fst p') mempty
-        in isBiStrictIn p result $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer p'
+        in isBiStrictIn p result $ CPS.runWriterT $ CPS.pass $ CPS.writer @SumInt @LazyIdentity p'
   ],
 
   -- == Functor/Applicative/Monad ==
   testGroup "Functor: fmap" [
-      testProperty "Lazy"    $ \m (p :: Bot (Int, Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return (unBotDeeper p)),
-      testProperty "Strict"  $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return (unBotDeeper p)),
-      testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ (+1) <$> CPS.writer (unBotDeeper p)
+      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (LazyIdentity (unBotDeeper p)),
+      testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ runLazyIdentity $ Strict.runWriterT $ (+1) <$> Strict.WriterT (LazyIdentity (unBotDeeper p)),
+      testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ (+1) <$> CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
     ],
 
   testGroup "Applicative: <*>" [
-      testProperty "Lazy"    $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+      testProperty "Lazy"    $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer (unBotDeeper p),
-      testProperty "Strict"  $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+         in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer (unBotDeeper p),
+      testProperty "Strict"  $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isBiStrictIn p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer (unBotDeeper p),
-      testProperty "CPS"     $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+         in isBiStrictIn p wf $ runLazyIdentity $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer (unBotDeeper p),
+      testProperty "CPS"     $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isBiStrictDeeperIn p wf $ withBaseMonad m $ CPS.runWriterT $ CPS.writer f' <*> CPS.writer (unBotDeeper p)
+         in isBiStrictDeeperIn p wf $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity f' <*> CPS.writer (unBotDeeper p)
     ],
 
   testGroup "Applicative: liftA2" [
-      testProperty "Lazy"    $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isLazy $ withBaseMonad m $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
-      testProperty "Strict"  $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
-      testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ liftA2 (+) (CPS.writer $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
+      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isLazy $ runLazyIdentity $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
+      testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ liftA2 (+) (Strict.writer $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
+      testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isBiStrictDeeperIn p q $ CPS.runWriterT $ liftA2 (+) (CPS.writer @SumInt @LazyIdentity $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
     ],
 
   testGroup "Monad: >>=" [
-      testProperty "Lazy"    $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p) >>= const (Lazy.writer (unBotDeeper q)),
-      testProperty "Strict"  $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer (unBotDeeper p) >>= const (Strict.writer (unBotDeeper q)),
-      testProperty "CPS"     $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
+      testProperty "Lazy"    $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+          isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p) >>= const (Lazy.writer $ unBotDeeper q),
+      testProperty "Strict"  $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ Strict.writer (unBotDeeper p) >>= const (Strict.writer $ unBotDeeper q),
+      testProperty "CPS"     $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+          isBiStrictDeeperIn p q $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
 
 
@@ -174,11 +185,10 @@ strictnessTest = [
       -- NOTE: foldMap is lazy for both Writers, since it only involves the value `a` of Writer w m a.
       testProperty "Lazy"    $ \(p :: [Bot (Int, SumInt)]) ->
           let p' = unBot <$> p
-          in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT p'),
+          in isLazy $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT p'),
       testProperty "Strict"  $ \(p :: [Bot (Int, SumInt)]) ->
           let p' = unBot <$> p
-          in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT p')
-
+          in isLazy $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT p')
       -- NOTE: no Foldable for CPS
   ],
 
@@ -199,22 +209,32 @@ strictnessTest = [
       testProperty "Lazy"  $
         \(Bot (p :: (Int, SumInt)))
          (Bot (q :: (Int, SumInt))) ->
-           isLazyValue $ evaluate $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
+           isLazy $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
       testProperty "Strict"  $
         \(Bot (p :: (Int, SumInt)))
          (Bot (q :: (Int, SumInt))) ->
-           isBiStrictIn p q $ evaluate $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
+           isBiStrictIn p q $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
       -- NOTE: no MonadZip for CPS
   ],
 
   testGroup "Contravariant: contramap" [
       testProperty "Lazy"   $ \(Bot (p :: (Int, SumInt))) ->
         let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id)
-        in isLazyValue $ f p,
+        in shouldBeBottom False $ f p,
       testProperty "Strict" $ \(Bot (p :: (Int, SumInt))) ->
         let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id)
-        in isStrictValue p $ f p
+        in isStrictIn p $ f p
       -- NOTE: no Contravariant for CPS
+  ],
+
+  testGroup "MonadFix: mfix" [
+      -- TODO: documentation
+      testProperty "Lazy"   $ \(Bot (p :: (Int, SumInt))) ->
+        isStrictIn p $ Lazy.runWriterT $ mfix (const $ Lazy.WriterT (Identity p)),
+      testProperty "Strict" $ \(Bot (p :: (Int, SumInt))) ->
+        isStrictIn p $ Strict.runWriterT $ mfix (const $ Strict.WriterT (Identity p)),
+      testProperty "CPS" $ \(Bot (p :: (Int, SumInt))) ->
+        isStrictIn p $ CPS.runWriterT $ mfix (const $ CPS.writer @SumInt @Identity p)
   ],
 
   testGroup "combination" [
@@ -226,12 +246,13 @@ strictnessTest = [
          (Bot (t :: (Int, SumInt)))
          (Bot (u :: (Int, SumInt)))
          (Bot (v :: (Int, SumInt))) ->
-           isLazy $ withBaseMonad m $ Lazy.runWriterT $ do
+           shouldBeBottomIO False $ withBaseMonad m $ Lazy.runWriterT $ do
              a <- Lazy.WriterT (return t)
              (b, x) <- Lazy.listen $ Lazy.WriterT $ return u
              Lazy.tell $ s <> x
              c <- Lazy.censor (<>r) $ Lazy.WriterT $ return v
              d <- Lazy.mapWriterT (unF1Bot f<$>) $ pure 0
+
              return $ a + b + c + d,
 
      testProperty "Strict" $
@@ -246,7 +267,7 @@ strictnessTest = [
              f' = unF1Bot f
              expected = isBottom t || isBottom u || isBottom v
               || isBottom (f' (0, mempty))
-           in shouldBeBottom expected $ withBaseMonad m $ Strict.runWriterT $ do
+           in shouldBeBottomIO expected $ withBaseMonad m $ Strict.runWriterT $ do
              a <- Strict.WriterT (return t)
              (b, x) <- Strict.listen $ Strict.WriterT $ return u
              Strict.tell $ s <> x
@@ -267,7 +288,7 @@ strictnessTest = [
              expected = isBottomDeeper t || isBottomDeeper u || isBottomDeeper v
               || isBottom s || isBottom r
               || isBottom (f' (0, mempty)) || isBottom (snd $ f' (0, mempty))
-           in shouldBeBottom expected $ withBaseMonad m $ CPS.runWriterT $ do
+           in shouldBeBottomIO expected $ withBaseMonad m $ CPS.runWriterT $ do
              a <- CPS.writer $ unBotDeeper t
              (b, x) <- CPS.listen $ CPS.writer $ unBotDeeper u
              CPS.tell $ s <> x
@@ -286,19 +307,13 @@ notBottomLabel = "Not _|_"
 bottomLabelFor :: String -> Bool -> String
 bottomLabelFor s x = s <> ": " <> (if x then bottomLabel else notBottomLabel)
 
-isStrictValue :: arg1 -> a -> Property
-isStrictValue x  = isStrictIn x . evaluate
-
-isLazyValue :: a -> Property
-isLazyValue = isLazy . evaluate
-
 -- Never bottom
-isLazy :: IO a -> Property
+isLazy :: a -> Property
 isLazy = shouldBeBottom False
 
 -- Strictness in one argument:
--- The result (normalized to IO) should be bottom whenever arg1 is bottom.
-isStrictIn :: arg1 -> IO a -> Property
+-- The result should be bottom whenever arg1 is bottom.
+isStrictIn :: arg1 -> a -> Property
 isStrictIn x  =
   let bottomX = isBottom x
   in label (bottomLabelFor "arg" bottomX)
@@ -306,16 +321,21 @@ isStrictIn x  =
 
 -- Strictness in two arguments:
 -- The result (normalized to IO) should be bottom whenever arg1 OR arg2 is bottom.
-isBiStrictIn :: arg1 -> arg2 -> IO o -> Property
+isBiStrictIn :: arg1 -> arg2 -> o -> Property
 isBiStrictIn x y  =
     let bottomX = isBottom x
         bottomY = isBottom y
    in label (bottomLabelFor "arg1" bottomX <> ", " <> bottomLabelFor "arg2" bottomY)
     . shouldBeBottom (bottomX || bottomY)
 
-shouldBeBottom :: Bool -> IO o -> Property
+shouldBeBottom :: Bool -> o -> Property
 shouldBeBottom expectBottom result = classify expectBottom bottomLabel $
+  isBottom result === expectBottom
+
+shouldBeBottomIO :: Bool -> IO o -> Property
+shouldBeBottomIO expectBottom result = classify expectBottom bottomLabel $
   if expectBottom
+    -- NOTE: TODO explain why assertExceptionIO is needed here
     then assertExceptionIO isBottomError result
     else ioProperty $ do
       v <- result
@@ -335,19 +355,19 @@ shouldBeBottom expectBottom result = classify expectBottom bottomLabel $
 -- Thus, for CPS tests, we expect the output to bottom whenever the input is bottom in either of the above ways.
 -- The "Deeper" assertions below are a deeper analogue of the assertions above which only check up to WHNF of the argument.
 
--- Deeper unBot for CPS. 
+-- Deeper unBot for CPS.
 -- See NOTE on deeper strictness above for details.
 unBotDeeper :: Bot (a, Bot w) -> (a, w)
 unBotDeeper = coerce
 
--- Deeper isBottom for CPS. 
+-- Deeper isBottom for CPS.
 -- See NOTE on deeper strictness above for details.
 isBottomDeeper :: Bot (a, Bot w) -> Bool
 isBottomDeeper (Bot p) = isBottom p || isBottom (snd p)
 
 -- Deeper strictness in one argument.
 -- The result (normalized to IO) should be bottom whenever (a, w) or w is bottom.
-isStrictDeeperIn :: Bot (a, Bot w) -> IO o -> Property
+isStrictDeeperIn :: Bot (a, Bot w) -> o -> Property
 isStrictDeeperIn p =
   let bottomP = isBottomDeeper p
   in label (bottomLabelFor "arg" bottomP)
@@ -355,7 +375,7 @@ isStrictDeeperIn p =
 
 -- Deeper strictness in two arguments:
 -- The result (normalized to IO) should be bottom whenever (a, w), (a', w'), w or w' is bottom.
-isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO o -> Property
+isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> o -> Property
 isBiStrictDeeperIn p q  =
   let bottomP = isBottomDeeper p
       bottomQ = isBottomDeeper q

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,35 +1,37 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module WriterStrictness (test) where
 
 import           Control.Applicative
-import           Control.Exception (ErrorCall (..), Exception,
-                                    SomeException (..), evaluate, throw)
+import           Control.Exception (ErrorCall (..), SomeException (..),
+                                    evaluate)
 import           Control.Monad
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
-import           Control.Monad.Signatures (CallCC, Catch)
+import           Control.Monad.Signatures (Catch)
 import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except (ExceptT (..), throwE)
-import           Control.Monad.Trans.Reader (ReaderT (..), ask)
+import           Control.Monad.Trans.Cont (ContT (..), callCC, runContT)
+import           Control.Monad.Trans.Except (ExceptT (..), catchE, throwE)
+import           Control.Monad.Trans.Reader (ReaderT (..), ask, reader)
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
 import           Control.Monad.Zip
 
 import           Data.Coerce
+import           Data.Either (fromRight)
 import           Data.Functor.Contravariant
 import           Data.Functor.Identity
 import           Data.Maybe
 import           Data.Monoid
+
+import           GHC.IO (unsafePerformIO)
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
@@ -43,56 +45,28 @@ test :: IO ()
 test = defaultMain $ testGroup "Writer" strictPairTests
 
 data WriterBase writer = WriterBase {
-    writer    :: forall w m a. m (a, w) -> writer w m a,
-    runWriter :: forall w m a. writer w m a -> m (a, w)
-  }
+  writer    :: forall w m a. m (a, w) -> writer w m a,
+  runWriter :: forall w m a. writer w m a -> m (a, w)
+}
 
 -- CPS Writer requires Functor
 data WriterBaseF writer = WriterBaseF {
-    writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
-    runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
-  }
+  writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
+  runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
+}
 
 data WriterMethods writer w m = WriterMethods {
-    execWriterT :: forall a.   writer w m a -> m w,
-    mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
-    tell        ::              w -> writer w m (),
-    listen      :: forall  a.   writer w m a -> writer w m (a, w),
-    pass        :: forall  a.   writer w m (a, w -> w) -> writer w m a,
-    censor      :: forall  a.   (w -> w) -> writer w m a -> writer w m a,
-    liftCallCC  :: forall  a b. CallCC m (a, w) (b, w) -> CallCC (writer w m) a b,
-    liftCatch   :: forall  a e. Catch e m (a, w) -> Catch e (writer w m) a
-  }
+  execWriterT :: forall a.    writer w m a -> m w,
+  mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
+  tell        ::              w -> writer w m (),
+  listen      :: forall  a.   writer w m a -> writer w m (a, w),
+  pass        :: forall  a.   writer w m (a, w -> w) -> writer w m a,
+  censor      :: forall  a.   (w -> w) -> writer w m a -> writer w m a
+}
 
-data StrictPairMethodsExpectations = StrictPairMethodsExpectations {
-    expect_bot_execWriter  :: Bool -> Bool,
-    expect_bot_mapWriter   :: Bool -> Bool,
-    expect_bot_tell        :: Bool -> Bool,
-    expect_bot_listen      :: Bool -> Bool,
-    expect_bot_pass        :: Bool -> Bool,
-    expect_bot_censor      :: Bool -> Bool,
-    expect_bot_liftCallCC  :: Bool -> Bool,
-    expect_bot_liftCatch   :: Bool -> Bool,
-    expect_bot_combination :: Bool -> Bool -> Bool -> Bool -> Bool
-  }
-
-data StrictPairMonadicExpectations = StrictPairMonadicExpectations {
-    expect_bot_functor_fmap      :: Bool -> Bool,
-    expect_bot_monad_bind        :: Bool -> Bool -> Bool,
-    expect_bot_applicative_apply :: Bool -> Bool -> Bool,
-    expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
-    expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
-    expect_bot_mfix              :: Bool -> Bool,
-    expect_bot_lift              :: Bool -> Bool,
-    expect_bot_nested            :: Bool -> Bool -> Bool 
-  }
-
-data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations {
-    expect_bot_foldMap   :: Bool -> Bool,
-    expect_bot_traverse  :: Bool -> Bool,
-    expect_bot_mzipWith  :: Bool -> Bool -> Bool,
-    expect_bot_contramap :: Bool -> Bool
-  }
+data WriterLifts writer = WriterLifts {
+  liftCatch   :: forall w m a e. Monoid w => Catch e m (a, w) -> Catch e (writer w m) a
+}
 
 lazyBaseF :: WriterBaseF Lazy.WriterT
 lazyBaseF = WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
@@ -100,18 +74,20 @@ lazyBaseF = WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
 lazyBase :: WriterBase Lazy.WriterT
 lazyBase = WriterBase {writer = Lazy.WriterT, runWriter = Lazy.runWriterT}
 
-lazyWriterMethods :: (Monad m, Monoid w) => WriterMethods Lazy.WriterT w m
-lazyWriterMethods =
-  WriterMethods {
-      execWriterT = Lazy.execWriterT,
-      mapWriter = Lazy.mapWriterT,
-      tell = Lazy.tell,
-      listen = Lazy.listen,
-      pass = Lazy.pass,
-      censor = Lazy.censor,
-      liftCallCC = Lazy.liftCallCC,
-      liftCatch = Lazy.liftCatch
-    }
+lazyWriterMethods :: (Monad m) => WriterMethods Lazy.WriterT w m
+lazyWriterMethods = WriterMethods {
+  execWriterT = Lazy.execWriterT,
+  mapWriter = Lazy.mapWriterT,
+  tell = Lazy.tell,
+  listen = Lazy.listen,
+  pass = Lazy.pass,
+  censor = Lazy.censor
+}
+
+lazyWriterLifts :: WriterLifts Lazy.WriterT
+lazyWriterLifts = WriterLifts {
+  liftCatch = Lazy.liftCatch
+}
 
 strictBaseF :: WriterBaseF Strict.WriterT
 strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWriterT}
@@ -119,7 +95,7 @@ strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWrit
 strictBase :: WriterBase Strict.WriterT
 strictBase = WriterBase {writer = Strict.WriterT, runWriter = Strict.runWriterT}
 
-strictWriterMethods :: (Monad m, Monoid w) => WriterMethods Strict.WriterT w m
+strictWriterMethods :: (Monad m) => WriterMethods Strict.WriterT w m
 strictWriterMethods =
   WriterMethods
     { execWriterT = Strict.execWriterT,
@@ -127,8 +103,11 @@ strictWriterMethods =
       tell = Strict.tell,
       listen = Strict.listen,
       pass = Strict.pass,
-      censor = Strict.censor,
-      liftCallCC = Strict.liftCallCC,
+      censor = Strict.censor
+    }
+
+strictWriterLifts :: WriterLifts Strict.WriterT
+strictWriterLifts = WriterLifts {
       liftCatch = Strict.liftCatch
     }
 
@@ -137,18 +116,22 @@ cpsBase = WriterBaseF {writerF = CPS.writerT, runWriterF = CPS.runWriterT}
 
 cpsWriterMethods :: (Monad m, Monoid w) => WriterMethods CPS.WriterT w m
 cpsWriterMethods =
-  WriterMethods
-    { execWriterT = CPS.execWriterT,
+  WriterMethods {
+      execWriterT = CPS.execWriterT,
       mapWriter = CPS.mapWriterT,
       tell = CPS.tell,
       listen = CPS.listen,
       pass = CPS.pass,
-      censor = CPS.censor,
-      liftCallCC = CPS.liftCallCC,
+      censor = CPS.censor
+    }
+
+cpsWriterLifts :: WriterLifts CPS.WriterT
+cpsWriterLifts = WriterLifts {
       liftCatch = CPS.liftCatch
     }
 
 -- Strictness tests for the *pair* (a, w)
+-- In particular this test is for
 --
 strictPairTests :: [TestTree]
 strictPairTests =
@@ -157,7 +140,7 @@ strictPairTests =
     lazyBase
     StrictPairTypeClassExpectations
       { expect_bot_foldMap = const False,
-        expect_bot_traverse = id, -- ISSUE?: not lazy pattern
+        expect_bot_traverse = id,           -- WARN: not lazy pattern
         expect_bot_mzipWith = const2 False,
         expect_bot_contramap = const False
       }
@@ -165,7 +148,7 @@ strictPairTests =
       "Strict"
       strictBase
       StrictPairTypeClassExpectations
-        { expect_bot_foldMap = const False, -- NOTE: same as lazy since it uses fst
+        { expect_bot_foldMap = const False, -- WARN: lazy due to use of fst
           expect_bot_traverse = id,
           expect_bot_mzipWith = (||),
           expect_bot_contramap = id
@@ -173,19 +156,20 @@ strictPairTests =
     ++ testStrictPairMonadic
       "Lazy"
       lazyBaseF
+      lazyWriterMethods
       StrictPairMonadicExpectations
         { expect_bot_functor_fmap = const False,
           expect_bot_monad_bind = const2 False,
           expect_bot_applicative_apply = const2 False,
           expect_bot_alternative_list = \x y -> or $ x <> y,
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = id, -- NOTE: same as strict
-          expect_bot_lift = const False,
-          expect_bot_nested = const2  False
+          expect_bot_mfix = id,             -- WARN: same as strict
+          expect_bot_stack = const2  False
         }
     ++ testStrictPairMonadic
       "Strict"
       strictBaseF
+      strictWriterMethods
       StrictPairMonadicExpectations
         { expect_bot_functor_fmap = id,
           expect_bot_monad_bind = (||),
@@ -193,12 +177,12 @@ strictPairTests =
           expect_bot_alternative_list = \x y -> or $ x <> y,
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
           expect_bot_mfix = id,
-          expect_bot_lift = const False, -- NOTE: same as lazy since it's just a wrapping
-          expect_bot_nested = (||)
+          expect_bot_stack = (||)
         }
     ++ testStrictPairMonadic
       "CPS"
       cpsBase
+      cpsWriterMethods
       StrictPairMonadicExpectations
         { expect_bot_functor_fmap = id,
           expect_bot_monad_bind = (||),
@@ -206,8 +190,7 @@ strictPairTests =
           expect_bot_alternative_list = \x y -> or $ x <> y,
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
           expect_bot_mfix = id,
-          expect_bot_lift = const False, -- NOTE: same as lazy since it's just a wrapping
-          expect_bot_nested = (||)
+          expect_bot_stack = (||)
         }
     ++ testStrictPairMethods
       "Lazy + Identity"
@@ -215,14 +198,12 @@ strictPairTests =
       lazyBaseF
       lazyWriterMethods
       StrictPairMethodsExpectations
-        { expect_bot_execWriter = id, -- NOTE: same as strict since reduces to the log w
-          expect_bot_mapWriter = id, -- NOTE: same as strict since it just applies a map on the pair (a, w)
-          expect_bot_tell = const False,
+        { expect_bot_execWriter = id,                -- NOTE: same as strict since it reduces to the log w
+          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
           expect_bot_listen = const False,
           expect_bot_pass = const False,
           expect_bot_censor = const False,
-          expect_bot_liftCallCC = const False,
-          expect_bot_liftCatch = const False,
           expect_bot_combination = const2 . const2 False
         }
     ++ testStrictPairMethods
@@ -232,13 +213,11 @@ strictPairTests =
       strictWriterMethods
       StrictPairMethodsExpectations
         { expect_bot_execWriter = id,
-          expect_bot_mapWriter = id,
-          expect_bot_tell = const False, -- NOTE: same as lazy since same implementation
+          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
           expect_bot_listen = id,
           expect_bot_pass = id,
           expect_bot_censor = id,
-          expect_bot_liftCallCC = id,
-          expect_bot_liftCatch = id,
           expect_bot_combination = \t u v w -> or [t, u, v, w]
         }
     ++ testStrictPairMethods
@@ -248,13 +227,11 @@ strictPairTests =
       cpsWriterMethods
       StrictPairMethodsExpectations
         { expect_bot_execWriter = id,
-          expect_bot_mapWriter = id,
-          expect_bot_tell = id,
+          expect_bot_mapWriter_strict = id,
+          expect_bot_mapWriter_lazy = id,
           expect_bot_listen = id,
           expect_bot_pass = id,
           expect_bot_censor = id,
-          expect_bot_liftCallCC = id,
-          expect_bot_liftCatch = id,
           expect_bot_combination = \t u v w -> or [t, u, v, w]
         }
     -- Maybe
@@ -264,33 +241,121 @@ strictPairTests =
       lazyBaseF
       lazyWriterMethods
       StrictPairMethodsExpectations
-        { expect_bot_execWriter = id, -- NOTE: same as strict since reduces to the log w
-          expect_bot_mapWriter = id, -- NOTE: same as strict since it just applies a map on the pair (a, w)
-          expect_bot_tell = const False,
+        { expect_bot_execWriter = id,             -- NOTE: same as strict since it reduces to the log w
+          expect_bot_mapWriter_strict = id,       -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
           expect_bot_listen = const False,
           expect_bot_pass = const False,
           expect_bot_censor = const False,
-          expect_bot_liftCallCC = const False,
-          expect_bot_liftCatch = const False,
           expect_bot_combination = const2 . const2 False
         }
     ++ testStrictPairMethods
-      "CPS + Identity"
+      "Strict + Maybe"
+      fromJust
+      strictBaseF
+      strictWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+    ++ testStrictPairMethods
+      "CPS + Maybe"
       fromJust
       cpsBase
       cpsWriterMethods
       StrictPairMethodsExpectations
         { expect_bot_execWriter = id,
-          expect_bot_mapWriter = id,
-          expect_bot_tell = id,
+          expect_bot_mapWriter_strict = id,
+          expect_bot_mapWriter_lazy = id,
           expect_bot_listen = id,
           expect_bot_pass = id,
           expect_bot_censor = id,
-          expect_bot_liftCallCC = id,
-          expect_bot_liftCatch = id,
           expect_bot_combination = \t u v w -> or [t, u, v, w]
         }
+    ++ testStrictPairMethods
+      "Lazy + IO"
+      unsafePerformIO
+      lazyBaseF
+      lazyWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,                -- NOTE: same as strict since it reduces to the log w
+          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
+          expect_bot_listen = const False,
+          expect_bot_pass = const False,
+          expect_bot_censor = const False,
+          expect_bot_combination = const2 . const2 False
+        }
+    ++ testStrictPairMethods
+      "Strict + IO"
+      unsafePerformIO
+      strictBaseF
+      strictWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
+          expect_bot_mapWriter_lazy = const False,
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+    ++ testStrictPairMethods
+      "CPS + IO"
+      unsafePerformIO
+      cpsBase
+      cpsWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter_strict = id,
+          expect_bot_mapWriter_lazy = id,
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+    ++ testStrictPairLifts
+      "Lazy"
+      lazyBaseF
+      lazyWriterLifts
+      StrictPairLiftsExpectations {
+        expect_bot_liftCatch = id             -- WARN: same as strict since the value is just passed through.
+      }
+    ++ testStrictPairLifts
+      "Strict"
+      strictBaseF
+      strictWriterLifts
+      StrictPairLiftsExpectations {
+        expect_bot_liftCatch = id
+      }
+    ++ testStrictPairLifts
+      "CPS"
+      cpsBase
+      cpsWriterLifts
+      StrictPairLiftsExpectations {
+        expect_bot_liftCatch = id
+      }
 
+-- Expected values of tests.
+data StrictPairMethodsExpectations = StrictPairMethodsExpectations {
+    expect_bot_execWriter       :: Bool -> Bool,
+    expect_bot_mapWriter_strict :: Bool -> Bool,
+    expect_bot_mapWriter_lazy   :: Bool -> Bool,
+    expect_bot_listen           :: Bool -> Bool,
+    expect_bot_pass             :: Bool -> Bool,
+    expect_bot_censor           :: Bool -> Bool,
+    expect_bot_combination      :: Bool -> Bool -> Bool -> Bool -> Bool
+  }
+
+-- |
+--
+-- Not tested:
+-- * tell
 testStrictPairMethods ::
   forall writer m.
   (Monad m, Monad (writer String m)) =>
@@ -301,32 +366,32 @@ testStrictPairMethods ::
   StrictPairMethodsExpectations ->
   [TestTree]
 testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
-  [ testProperty
-      (prop_name "execWriter")
+  [
+    testProperty
+        (prop_name "execWriter")
+        ( \(Bot v :: (Bot ((), String))) ->
+          let result = runMonad $ execWriterT $ writerF $ return @m v
+             in isBottom result === expect_bot_execWriter (isBottom v)
+        ),
+
+    -- NOTE: strictness depends only on the strictness of the provided map
+    testProperty
+      (prop_name "mapWriter - strict map")
       ( \(Bot v :: (Bot ((), String))) ->
-          let result = runW $ writerF $ return @m v
-           in isBottom result === expect_bot_execWriter (isBottom v)
+          let result = runIdentity $ runWriterF $ mapWriter fstrict $ writerF $ returnM v
+              fstrict = Identity . runMonad
+           in isBottom result === expect_bot_mapWriter_strict (isBottom v)
       ),
     testProperty
-      (prop_name "mapWriter - Identity")
+      (prop_name "mapWriter - lazy map")
       ( \(Bot v :: (Bot ((), String))) ->
-          let result = runIdentity $ runWriterF $ mapWriter f $ writerF $ returnM v
-              f = Identity . runMonad
-           in isBottom result === expect_bot_mapWriter (isBottom v)
+          let result = runWriterF $ mapWriter flazy $ writerF $ returnM v
+              flazy x = let ~(a, w) = runMonad x in Identity (a, w)
+           in isBottom result === expect_bot_mapWriter_lazy (isBottom v)
       ),
-    testProperty
-      (prop_name "mapWriter - Maybe")
-      ( \(Bot v :: (Bot ((), String))) ->
-          let result = fromMaybe ((), "_") $ runWriterF $ mapWriter f $ writerF $ returnM v
-              f = Just . runMonad
-           in isBottom result === expect_bot_mapWriter (isBottom v)
-      ),
-    testProperty
-      (prop_name "tell")
-      ( \(Bot v :: (Bot String)) ->
-          test_pair_strictness_monad runW (expect_bot_tell (isBottom v)) $
-            tell v
-      ),
+
+    -- NOTE: no test for tell since it does not involve pair values
+
     testProperty
       (prop_name "listen")
       ( \(Bot v :: (Bot ((), String))) ->
@@ -350,12 +415,6 @@ testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} Str
               writerF $
                 returnM v
       ),
-    testProperty
-      (prop_name "liftCallCC")
-      (label "TODO" $ property ()),
-    testProperty
-      (prop_name "liftCatch")
-      (label "TODO" $ property ()),
     testProperty
       (prop_name "combination")
       ( \(Bot t :: (Bot (Int, String)))
@@ -384,11 +443,59 @@ testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} Str
     returnM :: (a, w) -> m (a, w)
     returnM = return @m
 
-copyMonoid :: (Monoid w) => w -> w
-copyMonoid w = w <> w
+data StrictPairLiftsExpectations = StrictPairLiftsExpectations {
+    expect_bot_liftCatch  :: Bool -> Bool
+  }
 
-const2 :: a -> b -> c -> a
-const2 = const . const
+-- |
+-- In general, lifts do not involve pairs (a, w), since the log w is
+-- not visible to other monads in the stack.
+-- Hence, tests are omitted for:
+--
+-- * lift
+-- * liftIO
+-- * liftCallCC
+--
+testStrictPairLifts ::
+  forall writer.
+  String ->
+  WriterBaseF writer ->
+  WriterLifts writer ->
+  StrictPairLiftsExpectations ->
+  [TestTree]
+testStrictPairLifts testLabel WriterBaseF {..} WriterLifts {..} StrictPairLiftsExpectations {..} =
+  [
+    testProperty
+      (prop_name "liftCatch - no error")
+      ( \(Bot v :: (Bot ((), String))) ->
+        let
+           catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
+           catch = liftCatch catchE
+           writer = catch (writerF $ return v) e
+        in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
+              $ fromRight e <$> runExceptT (runWriterF writer)
+      ),
+    testProperty
+      (prop_name "liftCatch - handle error")
+      ( \(Bot v :: (Bot ((), String))) ->
+        let
+           catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
+           catch = liftCatch catchE
+           writer = catch (writerF $ throwE e) (const (writerF $ return v))
+        in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
+              $ fromRight e <$> runExceptT (runWriterF writer)
+      )
+  ]
+  where
+    e = error "this should never happen"
+    prop_name methodName = "[" <> testLabel <> "] " <> methodName
+
+data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations {
+    expect_bot_foldMap   :: Bool -> Bool,
+    expect_bot_traverse  :: Bool -> Bool,
+    expect_bot_mzipWith  :: Bool -> Bool -> Bool,
+    expect_bot_contramap :: Bool -> Bool
+  }
 
 testStrictPairTypeClass ::
   forall writer.
@@ -432,6 +539,16 @@ testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectation
   where
     prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
+data StrictPairMonadicExpectations = StrictPairMonadicExpectations {
+    expect_bot_functor_fmap      :: Bool -> Bool,
+    expect_bot_monad_bind        :: Bool -> Bool -> Bool,
+    expect_bot_applicative_apply :: Bool -> Bool -> Bool,
+    expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
+    expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
+    expect_bot_mfix              :: Bool -> Bool,
+    expect_bot_stack             :: Bool -> Bool -> Bool
+  }
+
 testStrictPairMonadic ::
   forall writer.
   ( MonadFix (writer String Maybe),
@@ -442,9 +559,10 @@ testStrictPairMonadic ::
   ) =>
   String ->
   WriterBaseF writer ->
+    WriterMethods writer String IO->
   StrictPairMonadicExpectations ->
   [TestTree]
-testStrictPairMonadic testLabel WriterBaseF {..} StrictPairMonadicExpectations {..} =
+testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMonadicExpectations {..} =
   [ testProperty
       (prop_name "Functor fmap")
       ( \(Bot v :: (Bot ((), String))) ->
@@ -514,77 +632,50 @@ testStrictPairMonadic testLabel WriterBaseF {..} StrictPairMonadicExpectations {
                 expected = expect_bot_alternative_list (isBottom <$> v') (isBottom <$> w')
              in any isBottom result === expected
       ),
+
     testProperty
-      (prop_name "MonadTrans lift")
-      ( \(Bot v :: (Bot ())) ->
-          let expected = expect_bot_lift (isBottom v)
-           in test_pair_strictness_IO (runWriterF @String) expected $
-                lift (return v)
-      ),
-    testProperty
-      (prop_name "MonadIO liftIO")
-      ( \(Bot v :: (Bot ())) ->
-          let expected = expect_bot_lift (isBottom v)
-           in test_pair_strictness_IO (runWriterF @String) expected $
-                liftIO (return v)
-      ),
-    testProperty
-      (prop_name "Monad nested")
+      (prop_name "Monad stack")
       ( \
-         (Bot u :: (Bot (Int, String)))
          (Bot v :: (Bot (Int, String)))
          (Bot w :: (Bot (Int, String)))
                 ->
-            let expected = expect_bot_nested (isBottom v) (isBottom w)
-                result :: TestMonad TestException (writer String IO) Int
-                result = TestMonad $ do
-                  s <- lift $ lift $ writerF $ return v
-                  a <- lift $ lift  $ writerF $ return w
-                  t <- lift ask
-                  when (isBottom u) $ throwE TestException
-                  return $ s + t * a
-             in test_pair_strictness_IO (runWriterF @String) (expected || isBottom u) $
-               runTestMonad result 
+            let expected = expect_bot_stack (isBottom v) (isBottom w)
+                result :: TestMonadStack String (writer String IO) Int
+                result = do
+                  w' <- lift $ lift $ writerF $ return w
+                  a <- lift ask
+                  b <- callCC $ \next -> do
+                    when (even a) $ next (10 ::Int)
+                    return 20
+                  v' <- lift $ lift $ writerF $ return v
+                  lift $ lift $ tell "hello"
+                  return $ w' + a + v' + b
+                writer = censor (filter (/= 'l')) $ runTestMonadStack result show
+             in test_pair_strictness_IO (runWriterF @String) expected writer
       )
   ]
   where
     prop_name methodName = "[" <> testLabel <> "]" <> methodName
 
-newtype TestMonad e m a = TestMonad (ExceptT e (ReaderT Int m) a)
-  deriving newtype (Functor, Applicative, Monad)
+copyMonoid :: (Monoid w) => w -> w
+copyMonoid w = w <> w
 
-data TestException = TestException
-  deriving (Show, Eq)
+const2 :: a -> b -> c -> a
+const2 = const . const
 
-instance Exception TestException where
+type TestMonadStack r m a = (ContT r (ReaderT Int m) a)
 
-instance MonadTrans (TestMonad e) where
-  lift m = TestMonad $ lift $ lift m
-
--- runTestMonad :: (MonadIO m, Exception e) => TestMonad e m a -> m a
-runTestMonad :: (MonadIO m) => TestMonad e m a -> m a
-runTestMonad (TestMonad m)  = do
-    result <- x
-    case result of
-      Right v -> return v
-      -- Left _  -> liftIO $ evaluate $ error "OOP"
-      -- Left _  -> liftIO $ evaluate $ error "OOP"
-      Left _  -> liftIO $ evaluate bottom
-      -- Left _  -> return y
-  where x = (runReaderT $ runExceptT m) 0
-
--- testMonad :: (Monad m) => m a -> TestMonad m a
--- testMonad = TestMonad . lift . lift
-
--- runTestMonad :: (Monad m) => TestMonad m Int -> (Int -> m Int) -> Int -> m Int
--- runTestMonad (TestMonad m) f = runReaderT (runContT m (lift . f))
+runTestMonadStack :: (Monad m) => TestMonadStack r m a -> (a -> r) -> m r
+runTestMonadStack m cont = runReaderT rd 0
+  where rd = runContT m $ \x -> reader $ const (cont x)
 
 test_pair_strictness_monad :: forall k writer w (m :: k) a b. (writer w m a -> b) -> Bool -> writer w m a -> Property
-test_pair_strictness_monad runW True wr =
-  assertExceptionIO @ErrorCall (const True) (evaluate $ runW wr)
-test_pair_strictness_monad runW False wr = monadicIO $ run $ runW wr `seq` return ()
+test_pair_strictness_monad runWriter expected writer = test_pair_strictness_IOBase expected $ evaluate (runWriter writer)
 
 test_pair_strictness_IO :: (writer w IO a -> IO b) -> Bool -> writer w IO a -> Property
-test_pair_strictness_IO runW True wr =
-  assertExceptionIO @ErrorCall (const True) (runW wr)
-test_pair_strictness_IO runW False wr = monadicIO $ run $ (`seq` ()) <$> runW wr
+test_pair_strictness_IO runW expected = test_pair_strictness_IOBase expected . runW
+
+test_pair_strictness_IOBase :: Bool -> IO a -> Property
+test_pair_strictness_IOBase True wr =
+  assertExceptionIO @ErrorCall (const True)  wr
+test_pair_strictness_IOBase False wr = monadicIO $ run $ (`seq` ()) <$> wr

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -10,7 +9,7 @@ import           Arbitrary
 import           Control.Applicative
 import           Control.Exception (ErrorCall (..))
 import           Control.Exception.Base (displayException)
-import           Control.Monad.Fix (MonadFix (..))
+import           Control.Monad.Fix
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
@@ -33,12 +32,12 @@ test = defaultMain $ testGroup "Writer" strictnessTest
 
 -- | NOTE: Monoid choice
 --
--- For the test, we use a monoid that is strict in both arguments of mappend :: a -> a -> a
+-- For the tests, we use a monoid that is strict in both arguments of mappend :: a -> a -> a
 --
 -- This is needed in particular to test a strictness property of the CPS writer, which
 -- is that it evaluates the log w strictly as it is accumulated.
--- If mappend is lazy in an argument, then outwardly the result appears the same with or without evaluation
--- and hence cannot be used for validation, which will complicate the tests.
+-- If mappend is lazy in either argument, then there would be no observable signal of
+-- strict evaluation in the result value, which would complicate the tests.
 -- e.g.
 --   List mappend is strict only in the first argument:
 --     writer ((), _|_) >> writer ((), "a")      _|_
@@ -53,61 +52,99 @@ type SumInt = Sum Int
 --
 -- Each writer variation is strict in the following ways:
 --
---  Writer.Lazy     non-strict in spine (a,w)
+--  Writer.Lazy     lazy in the computed value (a,w)
 --
---  Writer.Strict   strict in spine (a,w)
+--  Writer.Strict   strict in the computed value (a,w)
 --
---  Writer.CPS      strict in spine (a,w) and log w
+--  Writer.CPS      strict in the computed value (a,w) and log w
+--
+--
+-- = Choice of the underlying monad
+--
+-- For the purpose of the test, we use a monad with the following properties:
+-- a) strict in the monad bind i.e. a monad such that
+--
+--   x >>= k
+--
+-- is strict in k. In particular, x >>= _|_ is _|_ regardless of the value of x.
+--
+-- b) lazy as a data type.
+--
+-- We employ LazyIdentity since it is a simple monad that has both properties.
+--
+-- The reasoning is as follows.
+-- The distinguishing feature of the strict writer is that it is strict in the sequencing of computations.
+-- To be precise, this means that when binding in the underlying monad, the map k used
+-- is strict with the strict writer and lazy with the lazy writer.
+-- The map k of the CPS writer is further strict in the log w of (a, w) >>= k.
+-- Thus, in order to observe this effect in tests, we need to use a monad that preserves this property.
+--
+-- However, for the data type itself, we use one that is lazy.
+-- This is because otherwise, it becomes impossible to distinguish between a bottom of the monad itself or the computed value.
+-- e.g there is no difference between `Identity undefined` and `undefined`
+-- Writer function that require a Monad are typically the former, whereas functions that require only a Functor or an Applicative are the latter,
+-- since the caller has no control over the outer data constructor.
 --
 strictnessTest :: [TestTree]
 strictnessTest = [
   testGroup "writer" [
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p),
-      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p),
+      -- NOTE: Lazy and Strict are the same since there is no computational sequence involved.
+      -- The output is exactly the same as the input.
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) ->
+        isStrictIn p $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) ->
+        isStrictIn p $ runLazyIdentity $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p),
       testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   testGroup "execWriterT" [
-      -- NOTE: TODO explain why we use LazyIdentity here
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.execWriterT $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
-      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.execWriterT $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) ->
+        let result = Lazy.execWriterT $ Lazy.WriterT $ LazyIdentity (unBotDeeper p)
+         in isLazy result .&. isStrictDeeperIn p (runLazyIdentity result),
+      testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) ->
+        let result = Strict.execWriterT $ Strict.WriterT $ LazyIdentity (unBotDeeper p)
+         in isStrictIn p result .&. isStrictDeeperIn p (runLazyIdentity result),
       testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.execWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   -- Lazy, Strict Writer    output of map is used directly without any intervention by the Writer itself
-  --                        i.e. spine strict
   --
   -- CPS Writer             output of map is evaluated in the log w
   testGroup "mapWriter" [
       testProperty "Lazy"   $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
-            result = f' ((), mempty)
-        in isStrictIn result $ runLazyIdentity $ Lazy.runWriterT $ Lazy.mapWriterT @LazyIdentity (f'<$>) $ pure (),
+            v = f' ((), mempty)
+            result = Lazy.runWriterT $ Lazy.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+         -- Never bottoms in the outer constructor since the result of the map is used as is.
+         in isLazy result .&. isStrictIn v (runLazyIdentity result),
       testProperty "Strict" $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
-            result = f' ((), mempty)
-        in isStrictIn result $ runLazyIdentity $ Strict.runWriterT $ Strict.mapWriterT @LazyIdentity (f'<$>) $ pure (),
+            v = f' ((), mempty)
+            result = Strict.runWriterT $ Strict.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+         -- Never bottoms in the outer constructor since the result of the map is used as is.
+         in isLazy result .&. isStrictIn v (runLazyIdentity result),
       testProperty "CPS"    $ \(f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = coerce f :: ((), SumInt) -> ((), SumInt)
-            result = f' ((), mempty)
-        in isBiStrictIn result (snd result) $ CPS.runWriterT $ CPS.mapWriterT @LazyIdentity (f'<$>) $ pure ()
+            v = f' ((), mempty)
+        in isBiStrictIn v (snd v) $ CPS.runWriterT $ CPS.mapWriterT @LazyIdentity (f'<$>) $ pure ()
   ],
 
   testGroup "listen" [
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
       testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
       testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listen $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   testGroup "listens" [
-      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
+      testProperty "Lazy"   $ \(p :: Bot ((), Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ LazyIdentity (unBotDeeper p),
       testProperty "Strict" $ \(p :: Bot ((), Bot SumInt)) -> isStrictIn p $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ LazyIdentity (unBotDeeper p),
       testProperty "CPS"    $ \(p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ CPS.listens id $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
   ],
 
   testGroup "tell" [
-      testProperty "Lazy"   $ \(Bot (w :: SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.tell w,
-      testProperty "Strict" $ \(Bot (w :: SumInt)) -> isLazy $ runLazyIdentity $ Strict.runWriterT $ Strict.tell w,
+      -- NOTE: Lazy and Strict here are both lazy since there is no computational sequence involved here.
+      testProperty "Lazy"   $ \(Bot (w :: SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.tell @LazyIdentity w,
+      testProperty "Strict" $ \(Bot (w :: SumInt)) -> isValueLazy runLazyIdentity $ Strict.runWriterT $ Strict.tell @LazyIdentity w,
       testProperty "CPS"    $ \(Bot (w :: SumInt)) -> isStrictIn w $ CPS.runWriterT $ CPS.tell @SumInt @LazyIdentity w
   ],
 
@@ -118,7 +155,7 @@ strictnessTest = [
   testGroup "censor" [
       testProperty "Lazy"   $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
-        in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ LazyIdentity p,
+        in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ LazyIdentity p,
       testProperty "Strict" $ \(f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
         in isStrictIn p $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ LazyIdentity p,
@@ -132,7 +169,7 @@ strictnessTest = [
   testGroup "pass" [
       testProperty "Lazy"   $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-        in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ LazyIdentity p',
+        in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ LazyIdentity p',
       testProperty "Strict" $ \(p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
         in isStrictIn p $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ LazyIdentity p',
@@ -144,7 +181,8 @@ strictnessTest = [
 
   -- == Functor/Applicative/Monad ==
   testGroup "Functor: fmap" [
-      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) -> isLazy $ runLazyIdentity $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (LazyIdentity (unBotDeeper p)),
+      testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) -> isValueLazy runLazyIdentity $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (LazyIdentity (unBotDeeper p)),
+      -- Never bottoms in the outer constructor since Functor only exposes control over the inner value.
       testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ runLazyIdentity $ Strict.runWriterT $ (+1) <$> Strict.WriterT (LazyIdentity (unBotDeeper p)),
       testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ CPS.runWriterT $ (+1) <$> CPS.writer @SumInt @LazyIdentity (unBotDeeper p)
     ],
@@ -152,10 +190,11 @@ strictnessTest = [
   testGroup "Applicative: <*>" [
       testProperty "Lazy"    $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer (unBotDeeper p),
+         in isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity f' <*> Lazy.writer(unBotDeeper p),
       testProperty "Strict"  $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isBiStrictIn p wf $ runLazyIdentity $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer (unBotDeeper p),
+          -- Never bottoms in the outer constructor since Applicative only exposes control over the inner value.
+           in isBiStrictIn p f' $ runLazyIdentity $ Strict.runWriterT $ Strict.writer @LazyIdentity f' <*> Strict.writer(unBotDeeper p),
       testProperty "CPS"     $ \(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
          in isBiStrictDeeperIn p wf $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity f' <*> CPS.writer (unBotDeeper p)
@@ -163,18 +202,19 @@ strictnessTest = [
 
   testGroup "Applicative: liftA2" [
       testProperty "Lazy"    $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isLazy $ runLazyIdentity $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
+          isValueLazy runLazyIdentity $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer @LazyIdentity $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
       testProperty "Strict"  $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
-          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ liftA2 (+) (Strict.writer $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
+          -- Never bottoms in the outer constructor since Applicative only exposes control over the inner value.
+          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ liftA2 (+) (Strict.writer @LazyIdentity $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
       testProperty "CPS"     $ \(p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
           isBiStrictDeeperIn p q $ CPS.runWriterT $ liftA2 (+) (CPS.writer @SumInt @LazyIdentity $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
     ],
 
   testGroup "Monad: >>=" [
       testProperty "Lazy"    $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isLazy $ runLazyIdentity $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p) >>= const (Lazy.writer $ unBotDeeper q),
+          isValueLazy runLazyIdentity $ Lazy.runWriterT $ Lazy.writer @LazyIdentity (unBotDeeper p) >>= const (Lazy.writer $ unBotDeeper q),
       testProperty "Strict"  $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
-          isBiStrictIn p q $ runLazyIdentity $ Strict.runWriterT $ Strict.writer (unBotDeeper p) >>= const (Strict.writer $ unBotDeeper q),
+          isBiStrictIn p q $ Strict.runWriterT $ Strict.writer @LazyIdentity (unBotDeeper p) >>= const (Strict.writer $ unBotDeeper q),
       testProperty "CPS"     $ \(p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
           isBiStrictDeeperIn p q $ CPS.runWriterT $ CPS.writer @SumInt @LazyIdentity (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
@@ -227,14 +267,14 @@ strictnessTest = [
       -- NOTE: no Contravariant for CPS
   ],
 
+  -- NOTE: sufficient to just validate that mfix terminates
   testGroup "MonadFix: mfix" [
-      -- TODO: documentation
-      testProperty "Lazy"   $ \(Bot (p :: (Int, SumInt))) ->
-        isStrictIn p $ Lazy.runWriterT $ mfix (const $ Lazy.WriterT (Identity p)),
-      testProperty "Strict" $ \(Bot (p :: (Int, SumInt))) ->
-        isStrictIn p $ Strict.runWriterT $ mfix (const $ Strict.WriterT (Identity p)),
-      testProperty "CPS" $ \(Bot (p :: (Int, SumInt))) ->
-        isStrictIn p $ CPS.runWriterT $ mfix (const $ CPS.writer @SumInt @Identity p)
+      testProperty "Lazy"   $ \(p :: (Int, SumInt)) ->
+        p === runIdentity (Lazy.runWriterT $ mfix (const $ Lazy.WriterT (Identity p))),
+      testProperty "Strict" $ \(p :: (Int, SumInt)) ->
+        p === runIdentity (Strict.runWriterT $ mfix (const $ Strict.WriterT (Identity p))),
+      testProperty "CPS"    $ \(p :: (Int, SumInt)) ->
+        p === runIdentity (CPS.runWriterT $ mfix (const $ CPS.writer @SumInt @Identity p))
   ],
 
   testGroup "combination" [
@@ -311,6 +351,11 @@ bottomLabelFor s x = s <> ": " <> (if x then bottomLabel else notBottomLabel)
 isLazy :: a -> Property
 isLazy = shouldBeBottom False
 
+-- Never bottom not just in the outer constructor but in the inner value.
+-- This function ensures that we do not accidentally check only the outer constructor.
+isValueLazy :: (m a -> a) -> m a -> Property
+isValueLazy unWrap = shouldBeBottom False . unWrap
+
 -- Strictness in one argument:
 -- The result should be bottom whenever arg1 is bottom.
 isStrictIn :: arg1 -> a -> Property
@@ -374,7 +419,7 @@ isStrictDeeperIn p =
     . shouldBeBottom bottomP
 
 -- Deeper strictness in two arguments:
--- The result (normalized to IO) should be bottom whenever (a, w), (a', w'), w or w' is bottom.
+-- The result (normalized to IO) should be bottom whenever (a, w), (a', w'), w, or w' is bottom.
 isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> o -> Property
 isBiStrictDeeperIn p q  =
   let bottomP = isBottomDeeper p

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -27,16 +27,16 @@ import           Test.Tasty.QuickCheck
 test :: IO ()
 test = defaultMain $ testGroup "Writer" strictnessTest
 
--- | Monoid choice
+-- | NOTE: Monoid choice
 --
 -- For the test, we use a monoid that is strict in both arguments of mappend :: a -> a -> a
 --
 -- This is needed in particular to test a strictness property of the CPS writer, which
 -- is that it evaluates the log w strictly as it is accumulated.
 -- If mappend is lazy in an argument, then outwardly the result appears the same with or without evaluation
--- and hence cannot be validated.
+-- and hence cannot be used for validation, which will complicate the tests.
 -- e.g.
---   List mappend is only strict in the first argument:
+--   List mappend is strict only in the first argument:
 --     writer ((), _|_) >> writer ((), "a")      _|_
 --     writer ((), "a") >> writer ((), _|_)      ((), ('a':_|_))
 --
@@ -45,7 +45,7 @@ test = defaultMain $ testGroup "Writer" strictnessTest
 --     writer ((), _|_) >> writer ((), Sum 0)    _|_
 type SumInt = Sum Int
 
--- | Strictness test
+-- | NOTE: Strictness test
 --
 -- Each writer variation is strict in the following ways:
 --
@@ -100,13 +100,10 @@ strictnessTest = [
       testProperty "CPS"    $ \(m, Bot (w :: SumInt)) -> isStrictIn w $ withBaseMonad m $ CPS.runWriterT $ CPS.tell w
   ],
 
-  -- There are 3 levels of strictness to test:
-  -- 1) spine (a, w)
-  -- 2) log w
-  -- 3) log map w -> w
-  --
-  -- Lazy, Strict Writers are only concerned with 1.
-  -- CPS Writer is strict in all.
+  -- NOTE: strictness in the log w for censor (CPS only)
+  -- censor should be strict in the *final* value of the log w after applying the log censor (w -> w), 
+  -- not the initial value in the given writer.
+  -- Thus, for the tests below, a bottom log value is tested in the output of the log censor f, instead of the log w in the initial (a, w).
   testGroup "censor" [
       testProperty "Lazy"   $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
         let f' = coerce f :: SumInt -> SumInt
@@ -324,25 +321,40 @@ shouldBeBottom expectBottom result = classify expectBottom bottomLabel $
       v <- result
       v `seq` return ()
   where
-    -- Check error message only i.e. prefix, ignoring stacktrace.
+    -- Check error message only i.e. the prefix, ignoring the stacktrace.
     isBottomError :: ErrorCall -> Bool
     isBottomError e = "<bottom>" `isPrefixOf` displayException e
 
--- unBot for CPS which is strict in both the spine (a,w) and log w.
+
+-- | NOTE: Deeper strictness assertions for CPS
+--
+-- CPS Writer is strict in multiple levels, namely:
+-- a) strict in the spine (a, w)
+-- b) strict in the log w
+--
+-- Thus, for CPS tests, we expect the output to bottom whenever the input is bottom in either of the above ways.
+-- The "Deeper" assertions below are a deeper analogue of the assertions above which only check up to WHNF of the argument.
+
+-- Deeper unBot for CPS. 
+-- See NOTE on deeper strictness above for details.
 unBotDeeper :: Bot (a, Bot w) -> (a, w)
 unBotDeeper = coerce
 
--- isBottom for CPS, which is strict in both the spine (a,w) and log w.
+-- Deeper isBottom for CPS. 
+-- See NOTE on deeper strictness above for details.
 isBottomDeeper :: Bot (a, Bot w) -> Bool
 isBottomDeeper (Bot p) = isBottom p || isBottom (snd p)
 
--- isStrictIn analogue for deeper (CPS).
+-- Deeper strictness in one argument.
+-- The result (normalized to IO) should be bottom whenever (a, w) or w is bottom.
 isStrictDeeperIn :: Bot (a, Bot w) -> IO o -> Property
 isStrictDeeperIn p =
   let bottomP = isBottomDeeper p
   in label (bottomLabelFor "arg" bottomP)
     . shouldBeBottom bottomP
 
+-- Deeper strictness in two arguments:
+-- The result (normalized to IO) should be bottom whenever (a, w), (a, w'), w or w' is bottom.
 isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO o -> Property
 isBiStrictDeeperIn p q  =
   let bottomP = isBottomDeeper p

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module WriterStrictness (test) where
@@ -11,17 +9,13 @@ module WriterStrictness (test) where
 import           Arbitrary
 
 import           Control.Applicative
-import           Control.Arrow (first)
-import           Control.Exception (ErrorCall (..), SomeException (..),
-                                    evaluate)
+import           Control.Arrow (Arrow (second), first)
+import           Control.Exception (ErrorCall (..), evaluate)
 import           Control.Exception.Base (displayException)
 import           Control.Monad
 import           Control.Monad.Fix
-import           Control.Monad.IO.Class
-import           Control.Monad.Signatures (Catch)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Cont (ContT (..), callCC, runContT)
-import           Control.Monad.Trans.Except (ExceptT (..), catchE, throwE)
 import           Control.Monad.Trans.Reader (ReaderT (..), ask, reader)
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
@@ -29,14 +23,10 @@ import qualified Control.Monad.Trans.Writer.Strict as Strict
 import           Control.Monad.Zip
 
 import           Data.Coerce
-import           Data.Either (fromRight)
 import           Data.Functor.Contravariant
 import           Data.Functor.Identity
 import           Data.List (isPrefixOf)
-import           Data.Maybe
 import           Data.Monoid
-
-import           GHC.IO (unsafePerformIO)
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
@@ -45,506 +35,417 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 test :: IO ()
-test = defaultMain $ testGroup "Writer"
-  [
-    testGroup "Pair (a, w)" strictPairTests2,
-    testGroup "Log w" strictLogTest,
-    testGroup "Pair OLD" strictPairTests
-  ]
+test = defaultMain $ testGroup "Writer" strictSpineTest
 
-data WriterBase writer
-  = WriterBase
-      { writer    :: forall w m a. m (a, w) -> writer w m a,
-        runWriter :: forall w m a. writer w m a -> m (a, w)
-      }
+-- | Strictness test
+--
+--  TODO: documentation
+--
+--  TODO: CPS
+--
+strictSpineTest :: [TestTree]
+strictSpineTest = [
+  testGroup "writer" [
+      testProperty "Lazy"   $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p,
+      testProperty "Strict" $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p,
+      testProperty "CPS"    $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeep p)
+  ],
 
--- CPS Writer requires Functor
-data WriterBaseF writer
-  = WriterBaseF
-      { writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
-        runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
-      }
+ -- TODO: 
+  testGroup "mapWriter" [
+      testProperty "Lazy - lazy map"    $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT idLazy $ Lazy.WriterT $ return p,
+      testProperty "Lazy - strict map"  $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.WriterT $ return p,
 
-data WriterMethods writer w m
-  = WriterMethods
-      { execWriterT :: forall a. writer w m a -> m w,
-        mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
-        tell        :: w -> writer w m (),
-        listen      :: forall a. writer w m a -> writer w m (a, w),
-        pass        :: forall a. writer w m (a, w -> w) -> writer w m a,
-        censor      :: forall a. (w -> w) -> writer w m a -> writer w m a
-      }
+      testProperty "Strict - lazy map"  $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT idLazy $ Strict.WriterT $ return p,
+      testProperty "Strict - strict map"$ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.WriterT $ return p,
 
-data WriterLifts writer
-  = WriterLifts
-      { liftCatch :: forall w m a e. Monoid w => Catch e m (a, w) -> Catch e (writer w m) a
-      }
+      testProperty "CPS - lazy map"     $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT idLazy $ CPS.writer (unBotDeep p),
+      testProperty "CPS - strict map"   $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer (unBotDeep p)
+  ],
 
-lazyBaseF :: WriterBaseF Lazy.WriterT
-lazyBaseF = WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
+  testGroup "listen" [
+      testProperty "Lazy"   $ \m (Bot (p :: (Float, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return p,
+      testProperty "Strict" $ \m (Bot (p :: (Float, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (p :: Bot (Float, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeep p)
+  ],
 
-lazyBase :: WriterBase Lazy.WriterT
-lazyBase = WriterBase {writer = Lazy.WriterT, runWriter = Lazy.runWriterT}
+  testGroup "listens" [
+      testProperty "Lazy"   $ \m (Bot (p :: (Float, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.writer p,
+      testProperty "Strict" $ \m (Bot (p :: (Float, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.writer p,
+      testProperty "CPS"    $ \m (p :: Bot (Float, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeep p)
+  ],
 
-lazyWriterMethods :: (Monad m) => WriterMethods Lazy.WriterT w m
-lazyWriterMethods =
-  WriterMethods
-    { execWriterT = Lazy.execWriterT,
-      mapWriter = Lazy.mapWriterT,
-      tell = Lazy.tell,
-      listen = Lazy.listen,
-      pass = Lazy.pass,
-      censor = Lazy.censor
-    }
+  testGroup "tell" [
+      testProperty "Lazy"   $ \(m, Bot (w :: String)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.tell w,
+      testProperty "Strict" $ \(m, Bot (w :: String)) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.tell w,
+      testProperty "CPS"    $ \(m, Bot (w :: String)) -> isStrict w $ withBaseMonad m $ CPS.runWriterT $ CPS.tell w
+  ],
 
-lazyWriterLifts :: WriterLifts Lazy.WriterT
-lazyWriterLifts = WriterLifts { liftCatch = Lazy.liftCatch }
+  -- TODO: revisit function
+  testGroup "pass" [
+      testProperty "Lazy"   $ \m (p :: Bot ((), Bot String)) ->
+        let p' = p `seq` second (<>) $ unBotDeep p
+        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ return p',
+      testProperty "Strict" $ \m (p :: Bot ((), Bot String)) ->
+        let p' = p `seq` second (<>) $ unBotDeep p
+        in isStrict p' $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ return p',
+      testProperty "CPS"    $ \m (p :: Bot ((), Bot String)) ->
+        let p' = p `seq` second (<>) $ unBotDeep p
+        in isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ return p'
+  ],
 
-strictBaseF :: WriterBaseF Strict.WriterT
-strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWriterT}
+  -- NOTE: TODO note on Sum Int
+  testGroup "censor" [
+      testProperty "Lazy"   $ \m (Bot (w :: Sum Int)) (Bot (p :: ((), Sum Int))) ->
+        isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor (<> w) $ Lazy.WriterT $ return p,
+      testProperty "Strict" $ \m (Bot (w :: Sum Int)) (Bot (p :: ((), Sum Int))) ->
+        isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor (<> w) $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (Bot (w :: Sum Int)) (p :: Bot ((), Bot (Sum Int))) ->
+        isDeepStrict1 p w $ withBaseMonad m $ CPS.runWriterT $ CPS.censor (<> w) $ CPS.writer (unBotDeep p)
+  ],
 
-strictBase :: WriterBase Strict.WriterT
-strictBase = WriterBase {writer = Strict.WriterT, runWriter = Strict.runWriterT}
-
-strictWriterMethods :: (Monad m) => WriterMethods Strict.WriterT w m
-strictWriterMethods =
-  WriterMethods
-    { execWriterT = Strict.execWriterT,
-      mapWriter = Strict.mapWriterT,
-      tell = Strict.tell,
-      listen = Strict.listen,
-      pass = Strict.pass,
-      censor = Strict.censor
-    }
-
-strictWriterLifts :: WriterLifts Strict.WriterT
-strictWriterLifts =
-  WriterLifts
-    { liftCatch = Strict.liftCatch
-    }
-
-cpsBase :: WriterBaseF CPS.WriterT
-cpsBase = WriterBaseF {writerF = CPS.writerT, runWriterF = CPS.runWriterT}
-
-cpsWriterMethods :: (Monad m, Monoid w) => WriterMethods CPS.WriterT w m
-cpsWriterMethods =
-  WriterMethods
-    { execWriterT = CPS.execWriterT,
-      mapWriter = CPS.mapWriterT,
-      tell = CPS.tell,
-      listen = CPS.listen,
-      pass = CPS.pass,
-      censor = CPS.censor
-    }
-
-cpsWriterLifts :: WriterLifts CPS.WriterT
-cpsWriterLifts =
-  WriterLifts
-    { liftCatch = CPS.liftCatch
-    }
-
-
-data WriterProp a = WriterProp
-  { lazy   :: Prop a,
-    strict :: Prop a,
-    cps    :: Prop a
-  }
-
-data Prop a = Prop a | Unsupported
-
-runWriterProps :: Testable a => String -> WriterProp a -> TestTree
-runWriterProps name WriterProp {..} =
-  testGroup name $ catMaybes [
-    runProp "Lazy" lazy,
-    runProp "Strict" strict,
-    runProp "CPS" cps
-  ]
-    where
-      runProp monadName (Prop a) = Just $ testProperty monadName a
-      runProp _ Unsupported     = Nothing
-
-strictPairTests2 :: [TestTree]
-strictPairTests2 = [
-  runWriterProps "execWriter" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Lazy.execWriterT $ Lazy.writer v,
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Strict.execWriterT $ Strict.writer v,
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ CPS.execWriterT $ CPS.writer v
-  },
-  runWriterProps "mapWriter" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.writer v,
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.writer v,
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer v
-  },
-  runWriterProps "listen" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.writer v,
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.writer v,
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer v
-  },
-  runWriterProps "pass" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
-        let v' = coerce v :: ((), String -> String)
-        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ Lazy.writer (v', []),
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
-        let v' = coerce v :: ((), String -> String)
-        in isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.writer (v', []),
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
-        let v' = coerce v :: ((), String -> String)
-        in isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer (v', [])
-  },
-  runWriterProps "censor" WriterProp {
-      lazy   = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor id $ Lazy.writer v,
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.censor id $ Strict.writer v,
-      cps    = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.censor id $ CPS.writer v
-  },
 
   -- == Functor/Applicative/Monad ==
-  runWriterProps "Monad: >>=" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
-          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer v >>= const (Lazy.writer w),
-      strict = Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
-          isStrict2 v w $ withBaseMonad m $ Strict.runWriterT $ Strict.writer v >>= const (Strict.writer w),
-      cps =    Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
-          isStrict2 v w $ withBaseMonad m $ CPS.runWriterT $ CPS.writer v >>= const (CPS.writer w)
-    },
-  runWriterProps "Alternative: <|>" WriterProp {
-      lazy     = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)]
-              w' = coerce w :: [(Int, String)]
-           -- same as underlying alternative 
-           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT v' <|> Lazy.WriterT w')) === (isBottom <$> v' ++ w'),
-      strict   = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)]
-              w' = coerce w :: [(Int, String)]
-           in (isBottom <$> Strict.runWriterT (Strict.WriterT v' <|> Strict.WriterT w')) === (isBottom <$> v' ++ w'),
-      cps      = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)]
-              w' = coerce w :: [(Int, String)]
-           in (isBottom <$> CPS.runWriterT (CPS.writerT v' <|> CPS.writerT w')) === (isBottom <$> v' ++ w')
-    },
+  testGroup "Functor: fmap" [
+      testProperty "Lazy"    $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return p),
+      testProperty "Strict"  $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return p),
+      testProperty "CPS"     $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ (+1) <$> CPS.writer (unBotDeep p)
+    ],
+
+  testGroup "Applicative: <*>" [
+      testProperty "Lazy"    $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
+          let f' = coerce wf :: (() -> (), String)
+         in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer p ,
+      testProperty "Strict"  $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
+          let f' = coerce wf :: (() -> (), String)
+         in isStrict2 p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer p,
+      testProperty "CPS"     $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
+          let f' = coerce wf :: (() -> (), String)
+         in isStrict2 p wf $ withBaseMonad m $ CPS.runWriterT $ CPS.writer f' <*> CPS.writer p
+    ],
+
+  -- NOTE: TODO note on Sum Int
+  testGroup "Applicative: liftA2" [
+      testProperty "Lazy"    $ \m (Bot (p :: (Int, Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+          isLazy $ withBaseMonad m $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer p) (Lazy.writer q),
+      testProperty "Strict"  $ \m (Bot (p :: (Int, Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+          isStrict2 p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer p) (Strict.writer q),
+      testProperty "CPS"     $ \m (p :: Bot (Int, Bot (Sum Int))) (q :: Bot (Int, Bot (Sum Int))) ->
+          isDeepStrict2 p q $ withBaseMonad m $ CPS.runWriterT $ liftA2 (+) (CPS.writer $ unBotDeep p) (CPS.writer $ unBotDeep q)
+    ],
+
+  -- NOTE: TODO note on Sum Int
+  testGroup "Monad: >>=" [
+      testProperty "Lazy"        $ \m (Bot (p :: ((), Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p >>= const (Lazy.writer q),
+      testProperty "Strict"      $ \m (Bot (p :: ((), Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+          isStrict2 p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p >>= const (Strict.writer q),
+      testProperty "CPS"         $ \m (p :: Bot ((), Bot (Sum Int))) (q :: Bot (Int, Bot (Sum Int))) ->
+          isDeepStrict2 p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeep p) >>= const (CPS.writer (unBotDeep q))
+    ],
+
+  -- TODO
+  testGroup "Alternative: <|>" [
+      testProperty "Lazy"      $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p
+              q' = unBot <$> q
+           -- same as underlying alternative, so non-strict
+           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT p' <|> Lazy.WriterT q')) === (isBottom <$> p' ++ q'),
+      testProperty "Strict"   $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p 
+              q' = unBot <$> q
+           in (isBottom <$> Strict.runWriterT (Strict.WriterT p' <|> Strict.WriterT q')) === (isBottom <$> p' ++ q'),
+      testProperty "CPS"      $ \(p :: [Bot (Int, Bot String)]) (q :: [Bot (Int, Bot String)]) ->
+          let p' = unBotDeep <$> p
+              q' = unBotDeep <$> q
+           in (isBottom <$> CPS.runWriterT (CPS.writerT p' <|> CPS.writerT q')) === (isBottomDeep <$> p ++ q)
+    ],
+
+  -- TODO
+  testGroup "MonadPlus: mplus" [
+      testProperty "Lazy"      $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p
+              q' = unBot <$> q
+           -- same as underlying alternative, so non-strict
+           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT p' `mplus` Lazy.WriterT q')) === (isBottom <$> p' ++ q'),
+      testProperty "Strict"   $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p
+              q' = unBot <$> q 
+           in (isBottom <$> Strict.runWriterT (Strict.WriterT p' `mplus` Strict.WriterT q')) === (isBottom <$> p' ++ q'),
+      testProperty "CPS"      $ \(p :: [Bot (Int, Bot String)]) (q :: [Bot (Int, Bot String)]) ->
+          let p' = unBotDeep <$> p
+              q' = unBotDeep <$> q
+           in (isBottom <$> CPS.runWriterT (CPS.writerT p' `mplus` CPS.writerT q')) === (isBottomDeep <$> p ++ q)
+    ],
+
+  testGroup "MonadFix: >>=" [
+      -- NOTE: implementation of any fixed point functions must be lazy, so
+      -- mfix is lazy for all Writer types.
+      testProperty "Lazy" $ \(Bot (w :: String)) ->
+          isStrict w $ Lazy.runWriterT $ mfix (\x -> Lazy.writer $ w `seq` (w, x)),
+      testProperty "Strict" $ \(Bot (w :: String)) ->
+          isStrict w $ Strict.runWriterT $ mfix (\x -> Strict.writer $ w `seq` (w, x)),
+
+      -- TODO:
+      testProperty "CPS"    $ \(p :: Bot (Int, Bot String)) ->
+          isDeepStrict p $ CPS.runWriterT $ mfix (\x -> CPS.writer $ p `seq` first (x +) (unBotDeep p))
+    ],
+
+  -- TODO
+  testGroup "MonadStack" [
+    testProperty "Lazy" $
+       \(Bot (p :: (Int, String)))
+         (Bot (q :: (Int, String)))
+         ->
+            let
+                result :: TestMonadStack String (Lazy.WriterT String IO) Int
+                result = do
+                  q' <- lift $ lift $ Lazy.WriterT $ return q
+                  a <- lift ask
+                  b <- callCC $ \next -> do
+                    when (even a) $ next (10 :: Int)
+                    return 20
+                  p' <- lift $ lift $ Lazy.WriterT $ return p
+                  lift $ lift $ Lazy.tell "hello"
+                  return $ q' + a + p' + b
+                writer = Lazy.censor (filter (/= 'l')) $ runTestMonadStack result show
+             in isLazy $ Lazy.runWriterT writer,
+    testProperty "Strict" $
+       \(Bot (p :: (Int, String)))
+         (Bot (q :: (Int, String)))
+         ->
+            let
+                result :: TestMonadStack String (Strict.WriterT String IO) Int
+                result = do
+                  q' <- lift $ lift $ Strict.WriterT $ return q
+                  a <- lift ask
+                  b <- callCC $ \next -> do
+                    when (even a) $ next (10 :: Int)
+                    return 20
+                  p' <- lift $ lift $ Strict.WriterT $ return p
+                  lift $ lift $ Strict.tell "hello"
+                  return $ q' + a + p' + b
+                writer = Strict.censor (filter (/= 'l')) $ runTestMonadStack result show
+             in isStrict2 p q $ Strict.runWriterT writer
+  ],
+
 
   -- == Other type classes ==
-  runWriterProps "Foldable: foldMap" WriterProp {
+  testGroup "Foldable: foldMap" [
       -- NOTE: foldMap is lazy in both Lazy and Strict Writers due to the use of fst to pick the value.
-      lazy   = Prop $ \(v :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)] in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT v'),
-      strict = Prop $ \(v :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)] in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT v'),
-      cps    = Unsupported
-  },
-  runWriterProps "contramap" WriterProp {
-      lazy   = Prop $ \(Bot (v :: (Int, String))) ->
-          let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id) in isLazyValue $ f v,
-      strict = Prop $ \(Bot (v :: (Int, String))) ->
-          let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id) in isStrictValue v $ f v,
-      cps    = Unsupported
-  }
+      testProperty "Lazy"    $ \(p :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT p'),
+      testProperty "Strict"  $ \(p :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT p')
+      -- NOTE: no Foldable for CPS
+  ],
+
+  testGroup "Traversable: traverse" [
+      -- NOTE: traverse
+      testProperty "Lazy"    $ \(p :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p in isStrictAny p' $ evaluate $ traverse Just (Lazy.WriterT p'),
+      testProperty "Strict"  $ \(p :: [Bot (Int, String)]) ->
+          let p' = unBot <$> p in isStrictAny p' $ evaluate $ traverse Just (Strict.WriterT p')
+      -- NOTE: no Traversable for CPS
+  ],
+
+  testGroup "MonadZip: mzipWith" [
+      testProperty "Lazy"  $
+        \(Bot (p :: (Int, String)))
+         (Bot (q :: (Int, String))) ->
+            isLazyValue $ evaluate $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
+      testProperty "Strict"  $
+        \(Bot (p :: (Int, String)))
+         (Bot (q :: (Int, String))) ->
+           isStrict2 p q $ evaluate $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
+      -- NOTE: no MonadZip for CPS
+  ],
+
+  testGroup "Contravariant: contramap" [
+      testProperty "Lazy"   $ \(Bot (p :: (Int, String))) -> 
+        let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id) in isLazyValue $ f p,
+      testProperty "Strict" $ \(Bot (p :: (Int, String))) -> 
+        let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id) in isStrictValue p $ f p
+      -- NOTE: no MonadZip for CPS
+  ],
+
+  -- TODO
+  testGroup "combination" [
+     testProperty "Lazy" $
+       \ m
+         (Bot (t :: (Int, String)))
+         (Bot (u :: (Int, String)))
+         (Bot (v :: (Int, String)))
+         (Bot (w :: (Int, String))) ->
+           isLazy $ withBaseMonad m $ Lazy.runWriterT $ do
+                a <- Lazy.WriterT (return t)
+                (b, x) <- Lazy.listen $ Lazy.WriterT $ return u
+                Lazy.tell x
+                c <- Lazy.censor (drop 0) $ Lazy.WriterT $ return v
+                d <- Lazy.mapWriterT id $ Lazy.WriterT $ return w
+                return $ a + b + c + d,
+     testProperty "Strict" $
+       \ m
+         (Bot (t :: (Int, String)))
+         (Bot (u :: (Int, String)))
+         (Bot (v :: (Int, String)))
+         (Bot (w :: (Int, String)))
+         (s :: String) ->
+           let expected = isBottom t || isBottom u || isBottom v || isBottom w
+           in shouldBeBottom expected $ withBaseMonad m $ Strict.runWriterT $ do
+                a <- Strict.WriterT (return t)
+                (b, x) <- Strict.listen $ Strict.WriterT $ return u
+                Strict.tell (s ++ x)
+                c <- Strict.censor (drop 0) $ Strict.WriterT $ return v
+                d <- Strict.mapWriterT id $ Strict.WriterT $ return w
+                return $ a + b + c + d,
+     testProperty "CPS" $
+       \ m
+         (t :: Bot ((), Bot (Sum Int)))
+         (u :: Bot ((), Bot (Sum Int)))
+         (v :: Bot ((), Bot (Sum Int)))
+         (w :: Bot ((), Bot (Sum Int)))
+         (Bot (s :: (Sum Int))) ->
+           let expected = isBottomDeep t || isBottomDeep u || isBottomDeep v || isBottomDeep w || isBottom s
+               result =  withBaseMonad m $ CPS.runWriterT $ do
+                a <- CPS.writer $ unBotDeep t
+                (b, x) <- CPS.listen $ CPS.writer $ unBotDeep u
+                c <- CPS.censor id $ CPS.writer $ unBotDeep v
+                d <- CPS.mapWriterT id $ CPS.writer $ unBotDeep w
+                -- CPS.tell $ show $ a <> b <> c <> d
+                CPS.tell $ x <> s
+                return $ a <> b <> c <> d
+           in shouldBeBottom expected result
   ]
-
-strictLogTest :: [TestTree]
-strictLogTest = [
-  runWriterProps "runWriter" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.writer ((), v)),
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.writer ((), v)),
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.writer ((), v))
-  },
-  runWriterProps "mapWriter" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.writer (0 :: Int, v)),
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.writer(0 :: Int, v)),
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer (0 :: Int, v))
-  },
-  runWriterProps "listen" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.writer ((), v)),
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.writer ((), v)),
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer ((), v))
-  },
-  runWriterProps "tell" WriterProp {
-      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.tell v),
-      strict = Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.tell v),
-      cps =    Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.tell v)
-  }
   ]
+  where
+    idLazy :: Functor f => f (a, w) -> f (a, w)
+    idLazy = ((\ ~(a, w) -> (a, w)) <$>)
 
--- | Strictness tests for the value (a, w) of Writers
---
--- Test whether the pair (a, w) is handled lazily/strictly
--- in Writer functions as expected.
--- In particular, whether pairs patterns are handled correctly
--- in the respective Writers.
---
--- Please note that tests DO NOT test strictness in the log w
--- of the CPS writer.
---
-strictPairTests :: [TestTree]
-strictPairTests =
-  testStrictPairTypeClass
-    "Lazy"
-    lazyBase
-    StrictPairTypeClassExpectations
-      { expect_bot_foldMap = const False,
-        expect_bot_traverse = id,           -- NOTE: does not use lazy pattern match
-        expect_bot_mzipWith = const2 False,
-        expect_bot_contramap = const False
-      }
-    ++ testStrictPairTypeClass
-      "Strict"
-      strictBase
-      StrictPairTypeClassExpectations
-        { expect_bot_foldMap = const False, -- NOTE: lazy due to use of fst
-          expect_bot_traverse = id,
-          expect_bot_mzipWith = (||),
-          expect_bot_contramap = id
-        }
-    ++ testStrictPairMonadic
-      "Lazy"
-      lazyBaseF
-      lazyWriterMethods
-      StrictPairMonadicExpectations
-        { expect_bot_functor_fmap = const False,
-          expect_bot_monad_bind = const2 False,
-          expect_bot_applicative_apply = const2 False,
-          expect_bot_alternative_list = \x y -> or $ x <> y,
-          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = const False,
-          expect_bot_stack = const2 False
-        }
-    ++ testStrictPairMonadic
-      "Strict"
-      strictBaseF
-      strictWriterMethods
-      StrictPairMonadicExpectations
-        { expect_bot_functor_fmap = id,
-          expect_bot_monad_bind = (||),
-          expect_bot_applicative_apply = (||),
-          expect_bot_alternative_list = \x y -> or $ x <> y,
-          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = const False,       -- NOTE: fix must be lazy
-          expect_bot_stack = (||)
-        }
-    ++ testStrictPairMonadic
-      "CPS"
-      cpsBase
-      cpsWriterMethods
-      StrictPairMonadicExpectations
-        { expect_bot_functor_fmap = id,
-          expect_bot_monad_bind = (||),
-          expect_bot_applicative_apply = (||),
-          expect_bot_alternative_list = \x y -> or $ x <> y,
-          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = id,
-          expect_bot_stack = (||)
-        }
-    ++ testStrictPairMethods
-      "Lazy + Identity"
-      runIdentity
-      lazyBaseF
-      lazyWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,                -- NOTE: same as strict since it reduces to the log w
-          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = const False,
-          expect_bot_pass = const False,
-          expect_bot_censor = const False,
-          expect_bot_combination = const2 . const2 False
-        }
-    ++ testStrictPairMethods
-      "Strict + Identity"
-      runIdentity
-      strictBaseF
-      strictWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
-    ++ testStrictPairMethods
-      "CPS + Identity"
-      runIdentity
-      cpsBase
-      cpsWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,
-          expect_bot_mapWriter_lazy = id,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
-    ++ testStrictPairMethods
-      "Lazy + IO"
-      unsafePerformIO
-      lazyBaseF
-      lazyWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,                -- NOTE: same as strict since it reduces to the log w
-          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = const False,
-          expect_bot_pass = const False,
-          expect_bot_censor = const False,
-          expect_bot_combination = const2 . const2 False
-        }
-    ++ testStrictPairMethods
-      "Strict + IO"
-      unsafePerformIO
-      strictBaseF
-      strictWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
-    ++ testStrictPairMethods
-      "CPS + IO"
-      unsafePerformIO
-      cpsBase
-      cpsWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,
-          expect_bot_mapWriter_lazy = id,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
-    ++ testStrictPairLifts
-      "Lazy"
-      lazyBaseF
-      lazyWriterLifts
-      StrictPairLiftsExpectations
-        { expect_bot_liftCatch = id  -- NOTE: same as strict since the value is just passed through.
-        }
-    ++ testStrictPairLifts
-      "Strict"
-      strictBaseF
-      strictWriterLifts
-      StrictPairLiftsExpectations
-        { expect_bot_liftCatch = id
-        }
-    ++ testStrictPairLifts
-      "CPS"
-      cpsBase
-      cpsWriterLifts
-      StrictPairLiftsExpectations
-        { expect_bot_liftCatch = id
-        }
-
--- Expected values of tests.
-data StrictPairMethodsExpectations
-  = StrictPairMethodsExpectations
-      { expect_bot_execWriter       :: Bool -> Bool,
-        expect_bot_mapWriter_strict :: Bool -> Bool,
-        expect_bot_mapWriter_lazy   :: Bool -> Bool,
-        expect_bot_listen           :: Bool -> Bool,
-        expect_bot_pass             :: Bool -> Bool,
-        expect_bot_censor           :: Bool -> Bool,
-        expect_bot_combination      :: Bool -> Bool -> Bool -> Bool -> Bool
-      }
+-- -- | Strictness tests for the value (a, w) of Writers
+-- --
+-- -- Test whether the pair (a, w) is handled lazily/strictly
+-- -- in Writer functions as expected.
+-- -- In particular, whether pairs patterns are handled correctly
+-- -- in the respective Writers.
+-- --
+-- -- Please note that tests DO NOT test strictness in the log w
+-- -- of the CPS writer.
+-- --
+-- strictPairTests :: [TestTree]
+-- strictPairTests =
+--     testStrictPairLifts
+--       "Lazy"
+--       lazyBaseF
+--       lazyWriterLifts
+--       StrictPairLiftsExpectations
+--         { expect_bot_liftCatch = id  -- NOTE: same as strict since the value is just passed through.
+--         }
+--     ++ testStrictPairLifts
+--       "Strict"
+--       strictBaseF
+--       strictWriterLifts
+--       StrictPairLiftsExpectations
+--         { expect_bot_liftCatch = id
+--         }
+--     ++ testStrictPairLifts
+--       "CPS"
+--       cpsBase
+--       cpsWriterLifts
+--       StrictPairLiftsExpectations
+--         { expect_bot_liftCatch = id
+--         }
 
 -- | Value (a, w) strictness tests for the core Writer methods.
 --
 -- Functions that do not involve handling pairs are not tested:
 -- * tell
-testStrictPairMethods ::
-  forall writer m.
-  (Monad m, Monad (writer String m)) =>
-  String ->
-  (forall a. m a -> a) ->
-  WriterBaseF writer ->
-  WriterMethods writer String m ->
-  StrictPairMethodsExpectations ->
-  [TestTree]
-testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
-  [ testProperty
-      (prop_name "execWriter")
-      ( \(Bot v :: (Bot ((), String))) ->
-          let result = runMonad $ execWriterT $ writerF $ return @m v
-           in isBottom result === expect_bot_execWriter (isBottom v)
-      ),
+-- testStrictPairMethods ::
+--   forall writer m.
+--   (Monad m, Monad (writer String m)) =>
+--   String ->
+--   (forall a. m a -> a) ->
+--   WriterBaseF writer ->
+--   WriterMethods writer String m ->
+--   StrictPairMethodsExpectations ->
+--   [TestTree]
+-- testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
+--   [
+    -- testProperty
+    --   (prop_name "execWriter")
+    --   ( \(Bot v :: (Bot ((), String))) ->
+    --       let result = runMonad $ execWriterT $ writerF $ return @m v
+    --        in isBottom result === expect_bot_execWriter (isBottom v)
+    --   ),
 
     -- NOTE: strictness depends only on the strictness of the provided map
-    testProperty
-      (prop_name "mapWriter - strict map")
-      ( \(Bot v :: (Bot ((), String))) ->
-          let result = runIdentity $ runWriterF $ mapWriter fstrict $ writerF $ returnM v
-              fstrict = Identity . runMonad
-           in isBottom result === expect_bot_mapWriter_strict (isBottom v)
-      ),
-    testProperty
-      (prop_name "mapWriter - lazy map")
-      ( \(Bot v :: (Bot ((), String))) ->
-          let result = runWriterF $ mapWriter flazy $ writerF $ returnM v
-              flazy x = let ~(a, w) = runMonad x in Identity (a, w)
-           in isBottom result === expect_bot_mapWriter_lazy (isBottom v)
-      ),
+    -- testProperty
+    --   (prop_name "mapWriter - strict map")
+    --   ( \(Bot v :: (Bot ((), String))) ->
+    --       let result = runIdentity $ runWriterF $ mapWriter fstrict $ writerF $ returnM v
+    --           fstrict = Identity . runMonad
+    --        in isBottom result === expect_bot_mapWriter_strict (isBottom v)
+    --   ),
+    -- testProperty
+    --   (prop_name "mapWriter - lazy map")
+    --   ( \(Bot v :: (Bot ((), String))) ->
+    --       let result = runWriterF $ mapWriter flazy $ writerF $ returnM v
+    --           flazy x = let ~(a, w) = runMonad x in Identity (a, w)
+    --        in isBottom result === expect_bot_mapWriter_lazy (isBottom v)
+    --   ),
 
-    -- NOTE: no test for tell since it does not involve pair values
+    -- -- NOTE: no test for tell since it does not involve pair values
 
-    testProperty
-      (prop_name "listen")
-      ( \(Bot v :: (Bot ((), String))) ->
-          test_pair_strictness_monad runW (expect_bot_listen (isBottom v)) $
-            listen $ writerF $ returnM v
-      ),
-    testProperty
-      (prop_name "pass")
-      ( \(Bot v :: (Bot ((), F1 String String))) ->
-          let v' = coerce v :: ((), String -> String)
-           in test_pair_strictness_monad runW (expect_bot_pass (isBottom v)) $
-                pass $
-                  writerF $
-                    return (v', "")
-      ),
-    testProperty
-      (prop_name "censor")
-      ( \(Bot v :: (Bot ((), String))) ->
-          test_pair_strictness_monad runW (expect_bot_censor (isBottom v)) $
-            censor (\w -> w <> w) $
-              writerF $
-                returnM v
-      ),
-    testProperty
-      (prop_name "combination")
-      ( \(Bot t :: (Bot (Int, String)))
-         (Bot u :: (Bot (Int, String)))
-         (Bot v :: (Bot (Int, String)))
-         (Bot w :: (Bot (Int, String))) ->
-            let mt = writerF $ returnM t
-                mu = writerF $ returnM u
-                mv = writerF $ returnM v
-                mw = writerF $ returnM w
-                result = do
-                  a <- mt
-                  (b, x) <- listen mu
-                  tell x
-                  c <- censor (drop 0) mv
-                  d <- mapWriter id mw
-                  return $ a + b + c + d
-                expected = expect_bot_combination (isBottom t) (isBottom u) (isBottom v) (isBottom w)
-             in isBottom (runW result) === expected
-      )
-  ]
-  where
-    prop_name methodName = "[" <> testLabel <> "] " <> methodName
-    runW :: (Monoid w) => writer w m a -> (a, w)
-    runW = runMonad . runWriterF
-    returnM :: (a, w) -> m (a, w)
-    returnM = return @m
-
-data StrictPairLiftsExpectations
-  = StrictPairLiftsExpectations
-      { expect_bot_liftCatch :: Bool -> Bool
-      }
+    -- testProperty
+    --   (prop_name "listen")
+    --   ( \(Bot v :: (Bot ((), String))) ->
+    --       test_pair_strictness_monad runW (expect_bot_listen (isBottom v)) $
+    --         listen $ writerF $ returnM v
+    --   ),
+    -- testProperty
+    --   (prop_name "pass")
+    --   ( \(Bot v :: (Bot ((), F1 String String))) ->
+    --       let p' = coerce v :: ((), String -> String)
+    --        in test_pair_strictness_monad runW (expect_bot_pass (isBottom v)) $
+    --             pass $
+    --               writerF $
+    --                 return (p', "")
+    --   ),
+    -- testProperty
+    --   (prop_name "censor")
+    --   ( \(Bot v :: (Bot ((), String))) ->
+    --       test_pair_strictness_monad runW (expect_bot_censor (isBottom v)) $
+    --         censor (\w -> w <> w) $
+    --           writerF $
+    --             returnM v
+    --   ),
+    -- testProperty
+    --   (prop_name "combination")
+    --   ( \(Bot t :: (Bot (Int, String)))
+    --      (Bot u :: (Bot (Int, String)))
+    --      (Bot v :: (Bot (Int, String)))
+    --      (Bot w :: (Bot (Int, String))) ->
+    --         let mt = writerF $ returnM t
+    --             mu = writerF $ returnM u
+    --             mv = writerF $ returnM v
+    --             mw = writerF $ returnM w
+    --             result = do
+    --               a <- mt
+    --               (b, x) <- listen mu
+    --               tell x
+    --               c <- censor (drop 0) mv
+    --               d <- mapWriter id mw
+    --               return $ a + b + c + d
+    --             expected = expect_bot_combination (isBottom t) (isBottom u) (isBottom v) (isBottom w)
+    --          in isBottom (runW result) === expected
+    --   )
+  -- ]
+  -- where
+    -- prop_name methodName = "[" <> testLabel <> "] " <> methodName
+    -- runW :: (Monoid w) => writer w m a -> (a, w)
+    -- runW = runMonad . runWriterF
+    -- returnM :: (a, w) -> m (a, w)
+    -- returnM = return @m
 
 -- | Value (a, w) strictness tests for lifts.
 --
@@ -555,212 +456,194 @@ data StrictPairLiftsExpectations
 -- * liftIO
 -- * liftCallCC
 --
-testStrictPairLifts ::
-  forall writer.
-  String ->
-  WriterBaseF writer ->
-  WriterLifts writer ->
-  StrictPairLiftsExpectations ->
-  [TestTree]
-testStrictPairLifts testLabel WriterBaseF {..} WriterLifts {..} StrictPairLiftsExpectations {..} =
-  [
-    testProperty
-      (prop_name "liftCatch - no error")
-      ( \(Bot v :: (Bot ((), String))) ->
-        let
-           catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
-           catch = liftCatch catchE
-           writer = catch (writerF $ return v) e
-        in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
-              $ fromRight e <$> runExceptT (runWriterF writer)
-      ),
-    testProperty
-      (prop_name "liftCatch - handle error")
-      ( \(Bot v :: (Bot ((), String))) ->
-        let
-           catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
-           catch = liftCatch catchE
-           writer = catch (writerF $ throwE e) (const (writerF $ return v))
-        in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
-              $ fromRight e <$> runExceptT (runWriterF writer)
-      )
-  ]
-  where
-    e = error "this should never happen"
-    prop_name methodName = "[" <> testLabel <> "] " <> methodName
-
-data StrictPairTypeClassExpectations
-  = StrictPairTypeClassExpectations
-      { expect_bot_foldMap   :: Bool -> Bool,
-        expect_bot_traverse  :: Bool -> Bool,
-        expect_bot_mzipWith  :: Bool -> Bool -> Bool,
-        expect_bot_contramap :: Bool -> Bool
-      }
+-- testStrictPairLifts ::
+--   forall writer.
+--   String ->
+--   WriterBaseF writer ->
+--   WriterLifts writer ->
+--   StrictPairLiftsExpectations ->
+--   [TestTree]
+-- testStrictPairLifts testLabel WriterBaseF {..} WriterLifts {..} StrictPairLiftsExpectations {..} =
+--   [
+--     testProperty
+--       (prop_name "liftCatch - no error")
+--       ( \(Bot v :: (Bot ((), String))) ->
+--         let
+--            catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
+--            catch = liftCatch catchE
+--            writer = catch (writerF $ return v) e
+--         in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
+--               $ fromRight e <$> runExceptT (runWriterF writer)
+--       ),
+--     testProperty
+--       (prop_name "liftCatch - handle error")
+--       ( \(Bot v :: (Bot ((), String))) ->
+--         let
+--            catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
+--            catch = liftCatch catchE
+--            writer = catch (writerF $ throwE e) (const (writerF $ return v))
+--         in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
+--               $ fromRight e <$> runExceptT (runWriterF writer)
+--       )
+--   ]
+--   where
+--     e = error "this should never happen"
+--     prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
 -- | Value (a, w) strictness tests for type class functions other than Monads.
 --
-testStrictPairTypeClass ::
-  forall writer.
-  ( Traversable (writer String []),
-    Contravariant (writer String (Op (Int, String))),
-    MonadZip (writer String Identity)
-  ) =>
-  String ->
-  WriterBase writer ->
-  StrictPairTypeClassExpectations ->
-  [TestTree]
-testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectations {..} =
-  [ testProperty
-      (prop_name "foldMap")
-      ( \(v :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)]
-              result = getSum $ foldMap (const (Sum (0 :: Int))) (writer v')
-           in isBottom result === expect_bot_foldMap (any isBottom v)
-      ),
-    testProperty
-      (prop_name "traverse")
-      ( \(v :: [Bot (Int, String)]) ->
-          let v' = coerce v :: [(Int, String)]
-              result = traverse Just (writer v')
-           in isBottom (isBottom result) === expect_bot_foldMap (any isBottom v)
-      ),
-    testProperty
-      (prop_name "contramap")
-      ( \(Bot v :: (Bot (Int, String))) ->
-          let f = getOp $ runWriter $ contramap (+ 1) $ writer (Op id)
-           in isBottom (f v) === expect_bot_contramap (isBottom v)
-      ),
-    testProperty
-      (prop_name "mzipWith")
-      ( \(Bot v :: (Bot (Int, String)))
-         (Bot w :: (Bot (Int, String))) ->
-            let f = runWriter $ mzipWith (+) (writer (Identity v)) (writer (Identity w))
-             in isBottom f === expect_bot_mzipWith (isBottom v) (isBottom w)
-      )
-  ]
-  where
-    prop_name methodName = "[" <> testLabel <> "] " <> methodName
-
-data StrictPairMonadicExpectations
-  = StrictPairMonadicExpectations
-      { expect_bot_functor_fmap      :: Bool -> Bool,
-        expect_bot_monad_bind        :: Bool -> Bool -> Bool,
-        expect_bot_applicative_apply :: Bool -> Bool -> Bool,
-        expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
-        expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
-        expect_bot_mfix              :: Bool -> Bool,
-        expect_bot_stack             :: Bool -> Bool -> Bool
-      }
+-- testStrictPairTypeClass ::
+--   forall writer.
+--   ( Traversable (writer String []),
+--     Contravariant (writer String (Op (Int, String))),
+--     MonadZip (writer String Identity)
+--   ) =>
+--   String ->
+--   WriterBase writer ->
+--   StrictPairTypeClassExpectations ->
+--   [TestTree]
+-- testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectations {..} =
+--   [ testProperty
+--       (prop_name "foldMap")
+--       ( \(v :: [Bot (Int, String)]) ->
+--           let p' = coerce v :: [(Int, String)]
+--               result = getSum $ foldMap (const (Sum (0 :: Int))) (writer p')
+--            in isBottom result === expect_bot_foldMap (any isBottom v)
+--       ),
+--     testProperty
+--       (prop_name "traverse")
+--       ( \(v :: [Bot (Int, String)]) ->
+--           let p' = coerce v :: [(Int, String)]
+--               result = traverse Just (writer p')
+--            in isBottom (isBottom result) === expect_bot_foldMap (any isBottom v)
+--       ),
+--     testProperty
+--       (prop_name "contramap")
+--       ( \(Bot v :: (Bot (Int, String))) ->
+--           let f = getOp $ runWriter $ contramap (+ 1) $ writer (Op id)
+--            in isBottom (f v) === expect_bot_contramap (isBottom v)
+--       ),
+--     testProperty
+--       (prop_name "mzipWith")
+--       ( \(Bot v :: (Bot (Int, String)))
+--          (Bot w :: (Bot (Int, String))) ->
+--             let f = runWriter $ mzipWith (+) (writer (Identity v)) (writer (Identity w))
+--              in isBottom f === expect_bot_mzipWith (isBottom v) (isBottom w)
+--       )
+--   ]
+--   where
+--     prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
 -- | Value (a, w) strictness tests for Monadic typeclass functions.
 --
-testStrictPairMonadic ::
-  forall writer.
-  ( MonadFix (writer String Identity),
-    MonadPlus (writer String []),
-    MonadPlus (writer String Maybe),
-    MonadIO (writer String IO)
-  ) =>
-  String ->
-  WriterBaseF writer ->
-  WriterMethods writer String IO ->
-  StrictPairMonadicExpectations ->
-  [TestTree]
-testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMonadicExpectations {..} =
-  [ testProperty
-      (prop_name "Functor fmap")
-      ( \(Bot v :: (Bot ((), String))) ->
-          let expected = expect_bot_functor_fmap (isBottom v)
-           in test_pair_strictness_monad runWriterF expected $
-                (\w -> w <> w) <$> writerF (Identity v)
-      ),
-    testProperty
-      (prop_name "Monad >>=")
-      ( \(Bot v :: (Bot (Int, String)))
-         (Bot w :: (Bot ((), String))) -> do
-            let expected = expect_bot_monad_bind (isBottom v) (isBottom w)
-             in test_pair_strictness_monad runWriterF expected $
-                  writerF (Identity v) >>= const (writerF (Identity w))
-      ),
-    testProperty
-      (prop_name "Applicative <*>")
-      ( \(Bot v :: (Bot ((), String)))
-         (Bot u :: (Bot (F1 () (), String))) -> do
-            let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
-                u' :: (() -> (), String)
-                u' = coerce u
-             in test_pair_strictness_monad runWriterF expected $
-                  writerF (Identity u') <*> writerF (Identity v)
-      ),
-    testProperty
-      (prop_name "Applicative liftA2")
-      ( \(Bot v :: (Bot (Int, String)))
-         (Bot u :: (Bot (Int, String))) -> do
-            let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
-            test_pair_strictness_monad runWriterF expected $
-              liftA2 (+) (writerF (Identity v)) (writerF (Identity u))
-      ),
-    testProperty
-      -- NOTE: implementation of any fixed point functions must be lazy, so
-      -- mfix is lazy for all Writer types.
-      (prop_name "MonadFix mfix")
-      ( \(Bot v :: (Bot ([Int], String))) ->
-          let expected = expect_bot_mfix (isBottom v)
-           in test_pair_strictness_monad runWriterF expected $
-                mfix (\x -> writerF $ Identity $ first (x <>) v)
-      ),
-    testProperty
-      (prop_name "Alternative <|> - []")
-      ( \(v :: [Bot (Int, String)])
-         (w :: [Bot (Int, String)]) ->
-            let v' = coerce v :: [(Int, String)]
-                w' = coerce w :: [(Int, String)]
-                result = runWriterF $ writerF v' <|> writerF w'
-                expected = expect_bot_alternative_list (isBottom <$> v') (isBottom <$> w')
-             in any isBottom result === expected
-      ),
-    testProperty
-      (prop_name "Alternative <|> - Maybe")
-      ( \(v :: Maybe (Bot (Int, String)))
-         (w :: Maybe (Bot (Int, String))) ->
-            let v' = coerce v :: Maybe (Int, String)
-                w' = coerce w :: Maybe (Int, String)
-                result = runWriterF $ writerF v' `mplus` writerF w'
-             in any isBottom result === expect_bot_alternative_maybe (isBottom <$> v') (isBottom <$> w')
-      ),
-    testProperty
-      (prop_name "MonadPlus mplus - []")
-      ( \(v :: [Bot (Int, String)])
-         (w :: [Bot (Int, String)]) ->
-            let v' = coerce v :: [(Int, String)]
-                w' = coerce w :: [(Int, String)]
-                result = runWriterF $ writerF v' `mplus` writerF w'
-                expected = expect_bot_alternative_list (isBottom <$> v') (isBottom <$> w')
-             in any isBottom result === expected
-      ),
+-- testStrictPairMonadic ::
+--   forall writer.
+--   (
+--     -- MonadPlus (writer String []),
+--     -- MonadPlus (writer String Maybe),
+--     MonadIO (writer String IO)
+--   ) =>
+--   String ->
+--   WriterBaseF writer ->
+--   WriterMethods writer String IO ->
+--   StrictPairMonadicExpectations ->
+--   [TestTree]
+-- testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMonadicExpectations {..} =
+--   [
+  -- testProperty
+  --     (prop_name "Functor fmap")
+  --     ( \(Bot v :: (Bot ((), String))) ->
+  --         let expected = expect_bot_functor_fmap (isBottom v)
+  --          in test_pair_strictness_monad runWriterF expected $
+  --               (\w -> w <> w) <$> writerF (Identity v)
+  --     ),
+  --   testProperty
+  --     (prop_name "Monad >>=")
+  --     ( \(Bot v :: (Bot (Int, String)))
+  --        (Bot w :: (Bot ((), String))) -> do
+  --           let expected = expect_bot_monad_bind (isBottom v) (isBottom w)
+  --            in test_pair_strictness_monad runWriterF expected $
+  --                 writerF (Identity v) >>= const (writerF (Identity w))
+  --     ),
+  --   testProperty
+  --     (prop_name "Applicative <*>")
+  --     ( \(Bot v :: (Bot ((), String)))
+  --        (Bot u :: (Bot (F1 () (), String))) -> do
+  --           let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
+  --               u' :: (() -> (), String)
+  --               u' = coerce u
+  --            in test_pair_strictness_monad runWriterF expected $
+  --                 writerF (Identity u') <*> writerF (Identity v)
+  --     ),
+    -- testProperty
+    --   (prop_name "Applicative liftA2")
+    --   ( \(Bot v :: (Bot (Int, String)))
+    --      (Bot u :: (Bot (Int, String))) -> do
+    --         let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
+    --         test_pair_strictness_monad runWriterF expected $
+    --           liftA2 (+) (writerF (Identity v)) (writerF (Identity u))
+    --   ),
+    -- testProperty
+    --   -- NOTE: implementation of any fixed point functions must be lazy, so
+    --   -- mfix is lazy for all Writer types.
+    --   (prop_name "MonadFix mfix")
+    --   ( \(Bot v :: (Bot ([Int], String))) ->
+    --       let expected = expect_bot_mfix (isBottom v)
+    --        in test_pair_strictness_monad runWriterF expected $
+    --             mfix (\x -> writerF $ Identity $ first (x <>) v)
+    --   ),
+    -- testProperty
+    --   (prop_name "Alternative <|> - []")
+    --   ( \(v :: [Bot (Int, String)])
+    --      (w :: [Bot (Int, String)]) ->
+    --         let p' = coerce v :: [(Int, String)]
+    --             q' = coerce w :: [(Int, String)]
+    --             result = runWriterF $ writerF p' <|> writerF q'
+    --             expected = expect_bot_alternative_list (isBottom <$> p') (isBottom <$> q')
+    --          in any isBottom result === expected
+    --   ),
+    -- testProperty
+    --   (prop_name "Alternative <|> - Maybe")
+    --   ( \(v :: Maybe (Bot (Int, String)))
+    --      (w :: Maybe (Bot (Int, String))) ->
+    --         let p' = coerce v :: Maybe (Int, String)
+    --             q' = coerce w :: Maybe (Int, String)
+    --             result = runWriterF $ writerF p' `mplus` writerF q'
+    --          in any isBottom result === expect_bot_alternative_maybe (isBottom <$> p') (isBottom <$> q')
+    --   ),
+    -- testProperty
+    --   (prop_name "MonadPlus mplus - []")
+    --   ( \(v :: [Bot (Int, String)])
+    --      (w :: [Bot (Int, String)]) ->
+    --         let p' = coerce v :: [(Int, String)]
+    --             q' = coerce w :: [(Int, String)]
+    --             result = runWriterF $ writerF p' `mplus` writerF q'
+    --             expected = expect_bot_alternative_list (isBottom <$> p') (isBottom <$> q')
+    --          in any isBottom result === expected
+    --   ),
 
-    testProperty
-      (prop_name "Monad stack")
-      ( \(Bot v :: (Bot (Int, String)))
-         (Bot w :: (Bot (Int, String)))
-         ->
-            let expected = expect_bot_stack (isBottom v) (isBottom w)
-                result :: TestMonadStack String (writer String IO) Int
-                result = do
-                  w' <- lift $ lift $ writerF $ return w
-                  a <- lift ask
-                  b <- callCC $ \next -> do
-                    when (even a) $ next (10 :: Int)
-                    return 20
-                  v' <- lift $ lift $ writerF $ return v
-                  lift $ lift $ tell "hello"
-                  return $ w' + a + v' + b
-                writer = censor (filter (/= 'l')) $ runTestMonadStack result show
-             in test_pair_strictness_IO (runWriterF @String) expected writer
-      )
-  ]
-  where
-    prop_name methodName = "[" <> testLabel <> "]" <> methodName
+--     testProperty
+--       (prop_name "Monad stack")
+--       ( \(Bot v :: (Bot (Int, String)))
+--          (Bot w :: (Bot (Int, String)))
+--          ->
+--             let expected = expect_bot_stack (isBottom v) (isBottom w)
+--                 result :: TestMonadStack String (writer String IO) Int
+--                 result = do
+--                   q' <- lift $ lift $ writerF $ return w
+--                   a <- lift ask
+--                   b <- callCC $ \next -> do
+--                     when (even a) $ next (10 :: Int)
+--                     return 20
+--                   p' <- lift $ lift $ writerF $ return v
+--                   lift $ lift $ tell "hello"
+--                   return $ q' + a + p' + b
+--                 writer = censor (filter (/= 'l')) $ runTestMonadStack result show
+--              in test_pair_strictness_IO (runWriterF @String) expected writer
+--       )
+--   ]
+--   where
+--     prop_name methodName = "[" <> testLabel <> "]" <> methodName
 
 type TestMonadStack r m a = (ContT r (ReaderT Int m) a)
 
@@ -768,20 +651,8 @@ runTestMonadStack :: (Monad m) => TestMonadStack r m a -> (a -> r) -> m r
 runTestMonadStack m cont = runReaderT rd 0
   where rd = runContT m $ \x -> reader $ const (cont x)
 
-const2 :: a -> b -> c -> a
-const2 = const . const
-
-test_pair_strictness_monad :: (writer w m a -> b) -> Bool -> writer w m a -> Property
-test_pair_strictness_monad runWriter expected writer = test_pair_strictness_IOBase expected $ evaluate (runWriter writer)
-
-test_pair_strictness_IO :: (writer w IO a -> IO b) -> Bool -> writer w IO a -> Property
-test_pair_strictness_IO runW expected = test_pair_strictness_IOBase expected . runW
-
-test_pair_strictness_IOBase :: Bool -> IO a -> Property
-test_pair_strictness_IOBase True v = assertExceptionIO @ErrorCall (const True) v
-test_pair_strictness_IOBase False v = monadicIO $ run $ do
-  v' <- v
-  v' `seq` return ()
+unBotDeep :: Bot (a, Bot w) -> (a, w)
+unBotDeep = coerce
 
 isStrictValue :: arg1 -> a -> Property
 isStrictValue x  = isStrict x . evaluate
@@ -793,21 +664,37 @@ isLazyValue = isLazy . evaluate
 -- The result (normalized to IO) should be bottom whenever arg1 is bottom.
 isStrict :: arg1 -> IO a -> Property
 isStrict x  = shouldBeBottom (isBottom x)
+--   where p' = unBot p
 
 -- Strictness in two arguments:
 -- The result (normalized to IO) should be bottom whenever arg1 OR arg2 is bottom.
 isStrict2 :: arg1 -> arg2 -> IO a -> Property
 isStrict2 x y  = shouldBeBottom (isBottom x || isBottom y)
 
+isBottomDeep :: Bot (a, Bot w) -> Bool
+isBottomDeep (Bot p) = isBottom p || isBottom (snd p)
+
+isDeepStrict :: Bot (a, Bot w) -> IO b -> Property
+isDeepStrict p  = shouldBeBottom (isBottomDeep p)
+
+isDeepStrict2 :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO b -> Property
+isDeepStrict2 p q  = shouldBeBottom (isBottomDeep p || isBottomDeep q)
+
+isDeepStrict1 :: Bot (a, Bot w) -> arg1 -> IO b -> Property
+isDeepStrict1 p y  = shouldBeBottom (isBottomDeep p || isBottom y)
+
+isStrictAny :: [arg] -> IO a -> Property
+isStrictAny x = shouldBeBottom (any isBottom x)
+
 isLazy :: IO a -> Property
 isLazy = shouldBeBottom False
 
 shouldBeBottom :: Bool -> IO a -> Property
-shouldBeBottom True result = assertExceptionIO isBottomError result
+shouldBeBottom True result = label "Bottom" $ assertExceptionIO isBottomError result
   where
     -- Check error message only i.e. prefix, ignoring stacktrace.
     isBottomError :: ErrorCall -> Bool
     isBottomError e = "<bottom>" `isPrefixOf` displayException e
-shouldBeBottom False result = monadicIO $ run $ do
+shouldBeBottom False result = label "not Bottom" $ monadicIO $ run $ do
   v <- result
   v `seq` return ()

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,205 +1,564 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module WriterStrictness (test) where
 
 import Control.Applicative
-import Control.Exception.Base (ErrorCall)
-import Control.Monad.Fix (mfix)
+import Control.Exception (ErrorCall, evaluate)
+import Control.Monad
+import Control.Monad.Fix
+import Control.Monad.IO.Class
+import Control.Monad.Signatures (CallCC, Catch)
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Cont
+import Control.Monad.Trans.Reader (ReaderT (..), ask)
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
-import Data.Functor.Contravariant (Contravariant (contramap), Predicate (..))
-import GHC.IO (evaluate)
-import Test.ChasingBottoms (bottom)
+import Control.Monad.Zip
+import Data.Coerce
+import Data.Functor.Contravariant
+import Data.Functor.Identity
+import Data.Maybe
+import Data.Monoid
 import Test.ChasingBottoms.IsBottom (isBottom)
 import Test.QuickCheck
 import Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
 import Test.Tasty
 import Test.Tasty.QuickCheck
-import Utils (Bot (..))
+import Utils
 
 test :: IO ()
-test = do
-  defaultMain $ testGroup "Writer" tests
+test = defaultMain $ testGroup "Writer" strictPairTests
 
-tests :: [TestTree]
-tests =
-  -- Basic methods
-  [ testFunction
-      "execWriter"
-      ( \(Bot v :: (Bot (String, ()))) ->
-          isBottom (Strict.execWriter $ Strict.writer v)
-            === isBottom v
-      )
-      ( \(Bot v :: (Bot (String, ()))) ->
-          isBottom (Lazy.execWriter $ Lazy.writer v)
-            === isBottom v
-      )
-      ( \(Bot v :: (Bot (String, ()))) ->
-          isBottom (CPS.execWriter $ CPS.writer v)
-            === isBottom v
+data WriterBase writer = WriterBase
+  { writer :: forall w m a. (Monoid w) => m (a, w) -> writer w m a,
+    runWriter :: forall w m a. (Monoid w) => writer w m a -> m (a, w)
+  }
+
+-- CPS Writer requires Functor
+data WriterBaseF writer = WriterBaseF
+  { writerF :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
+    runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
+  }
+
+data WriterMethods writer = WriterMethods
+  { execWriterT :: forall w m a. (Monad m, Monoid w) => writer w m a -> m w,
+    mapWriter :: forall w m a w' n b. (Monad n, Monoid w, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
+    tell :: forall w m. (Monad m, Monoid w) => w -> writer w m (),
+    listen :: forall w m a. (Monad m, Monoid w) => writer w m a -> writer w m (a, w),
+    pass :: forall w m a. (Monad m, Monoid w) => writer w m (a, w -> w) -> writer w m a,
+    censor :: forall w m a. (Monad m, Monoid w) => (w -> w) -> writer w m a -> writer w m a,
+    liftCallCC :: forall w m a b. (Monad m, Monoid w) => CallCC m (a, w) (b, w) -> CallCC (writer w m) a b,
+    liftCatch :: forall w m a e. Catch e m (a, w) -> Catch e (writer w m) a
+  }
+
+data StrictPairMethodsExpectations = StrictPairMethodsExpectations
+  { expect_bot_execWriter :: Bool -> Bool,
+    expect_bot_mapWriter :: Bool -> Bool,
+    expect_bot_tell :: Bool -> Bool,
+    expect_bot_listen :: Bool -> Bool,
+    expect_bot_pass :: Bool -> Bool,
+    expect_bot_censor :: Bool -> Bool,
+    expect_bot_liftCallCC :: Bool -> Bool,
+    expect_bot_liftCatch :: Bool -> Bool,
+    expect_bot_combination :: Bool -> Bool -> Bool -> Bool -> Bool
+  }
+
+data StrictPairMonadicExpectations = StrictPairMonadicExpectations
+  { expect_bot_functor_fmap :: Bool -> Bool,
+    expect_bot_monad_bind :: Bool -> Bool -> Bool,
+    expect_bot_applicative_apply :: Bool -> Bool -> Bool,
+    expect_bot_alternative_list :: [Bool] -> [Bool] -> Bool,
+    expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
+    expect_bot_mfix :: Bool -> Bool,
+    expect_bot_lift :: Bool -> Bool,
+    expect_bot_nested :: Bool -> Bool -> Bool
+  }
+
+data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations
+  { expect_bot_foldMap :: Bool -> Bool,
+    expect_bot_traverse :: Bool -> Bool,
+    expect_bot_mzipWith :: Bool -> Bool -> Bool,
+    expect_bot_contramap :: Bool -> Bool
+  }
+
+lazyBaseF :: WriterBaseF Lazy.WriterT
+lazyBaseF =
+  WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
+
+lazyBase :: WriterBase Lazy.WriterT
+lazyBase = WriterBase {writer = Lazy.WriterT, runWriter = Lazy.runWriterT}
+
+lazyWriterMethods :: WriterMethods Lazy.WriterT
+lazyWriterMethods =
+  WriterMethods
+    { execWriterT = Lazy.execWriterT,
+      mapWriter = Lazy.mapWriterT,
+      tell = Lazy.tell,
+      listen = Lazy.listen,
+      pass = Lazy.pass,
+      censor = Lazy.censor,
+      liftCallCC = Lazy.liftCallCC,
+      liftCatch = Lazy.liftCatch
+    }
+
+strictBaseF :: WriterBaseF Strict.WriterT
+strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWriterT}
+
+strictBase :: WriterBase Strict.WriterT
+strictBase = WriterBase {writer = Strict.WriterT, runWriter = Strict.runWriterT}
+
+strictWriterMethods :: WriterMethods Strict.WriterT
+strictWriterMethods =
+  WriterMethods
+    { execWriterT = Strict.execWriterT,
+      mapWriter = Strict.mapWriterT,
+      tell = Strict.tell,
+      listen = Strict.listen,
+      pass = Strict.pass,
+      censor = Strict.censor,
+      liftCallCC = Strict.liftCallCC,
+      liftCatch = Strict.liftCatch
+    }
+
+cpsBase :: WriterBaseF CPS.WriterT
+cpsBase = WriterBaseF {writerF = CPS.writerT, runWriterF = CPS.runWriterT}
+
+cpsWriterMethods :: WriterMethods CPS.WriterT
+cpsWriterMethods =
+  WriterMethods
+    { execWriterT = CPS.execWriterT,
+      mapWriter = CPS.mapWriterT,
+      tell = CPS.tell,
+      listen = CPS.listen,
+      pass = CPS.pass,
+      censor = CPS.censor,
+      liftCallCC = CPS.liftCallCC,
+      liftCatch = CPS.liftCatch
+    }
+
+-- Strictness tests for the *pair* (a, w)
+--
+strictPairTests :: [TestTree]
+strictPairTests =
+  testStrictPairTypeClass
+    "Lazy"
+    lazyBase
+    StrictPairTypeClassExpectations
+      { expect_bot_foldMap = const False,
+        expect_bot_traverse = id, -- ISSUE?: not lazy pattern
+        expect_bot_mzipWith = const2 False,
+        expect_bot_contramap = const False
+      }
+    ++ testStrictPairTypeClass
+      "Strict"
+      strictBase
+      StrictPairTypeClassExpectations
+        { expect_bot_foldMap = const False, -- NOTE: same as lazy since it uses fst
+          expect_bot_traverse = id,
+          expect_bot_mzipWith = (||),
+          expect_bot_contramap = id
+        }
+    ++ testStrictPairMonadic
+      "Lazy"
+      lazyBaseF
+      StrictPairMonadicExpectations
+        { expect_bot_functor_fmap = const False,
+          expect_bot_monad_bind = const2 False,
+          expect_bot_applicative_apply = const2 False,
+          expect_bot_alternative_list = \x y -> or $ x <> y,
+          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
+          expect_bot_mfix = id, -- NOTE: same as strict
+          expect_bot_lift = const False,
+          expect_bot_nested = const2 False
+        }
+    ++ testStrictPairMonadic
+      "Strict"
+      strictBaseF
+      StrictPairMonadicExpectations
+        { expect_bot_functor_fmap = id,
+          expect_bot_monad_bind = (||),
+          expect_bot_applicative_apply = (||),
+          expect_bot_alternative_list = \x y -> or $ x <> y,
+          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
+          expect_bot_mfix = id,
+          expect_bot_lift = const False, -- NOTE: same as lazy since it's just a wrapping
+          expect_bot_nested = (||)
+        }
+    ++ testStrictPairMonadic
+      "CPS"
+      cpsBase
+      StrictPairMonadicExpectations
+        { expect_bot_functor_fmap = id,
+          expect_bot_monad_bind = (||),
+          expect_bot_applicative_apply = (||),
+          expect_bot_alternative_list = \x y -> or $ x <> y,
+          expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
+          expect_bot_mfix = id,
+          expect_bot_lift = const False, -- NOTE: same as lazy since it's just a wrapping
+          expect_bot_nested = (||)
+        }
+    ++ testStrictPairMethods
+      "Lazy + Identity"
+      runIdentity
+      lazyBaseF
+      lazyWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id, -- NOTE: same as strict since reduces to the log w
+          expect_bot_mapWriter = id, -- NOTE: same as strict since it just applies a map on the pair (a, w)
+          expect_bot_tell = const False,
+          expect_bot_listen = const False,
+          expect_bot_pass = const False,
+          expect_bot_censor = const False,
+          expect_bot_liftCallCC = const False,
+          expect_bot_liftCatch = const False,
+          expect_bot_combination = const2 . const2 False
+        }
+    ++ testStrictPairMethods
+      "Strict + Identity"
+      runIdentity
+      strictBaseF
+      strictWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter = id,
+          expect_bot_tell = const False, -- NOTE: same as lazy since same implementation
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_liftCallCC = id,
+          expect_bot_liftCatch = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+    ++ testStrictPairMethods
+      "CPS + Identity"
+      runIdentity
+      cpsBase
+      cpsWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter = id,
+          expect_bot_tell = id,
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_liftCallCC = id,
+          expect_bot_liftCatch = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+    -- Maybe
+    ++ testStrictPairMethods
+      "Lazy + Maybe"
+      fromJust
+      lazyBaseF
+      lazyWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id, -- NOTE: same as strict since reduces to the log w
+          expect_bot_mapWriter = id, -- NOTE: same as strict since it just applies a map on the pair (a, w)
+          expect_bot_tell = const False,
+          expect_bot_listen = const False,
+          expect_bot_pass = const False,
+          expect_bot_censor = const False,
+          expect_bot_liftCallCC = const False,
+          expect_bot_liftCatch = const False,
+          expect_bot_combination = const2 . const2 False
+        }
+    ++ testStrictPairMethods
+      "CPS + Identity"
+      fromJust
+      cpsBase
+      cpsWriterMethods
+      StrictPairMethodsExpectations
+        { expect_bot_execWriter = id,
+          expect_bot_mapWriter = id,
+          expect_bot_tell = id,
+          expect_bot_listen = id,
+          expect_bot_pass = id,
+          expect_bot_censor = id,
+          expect_bot_liftCallCC = id,
+          expect_bot_liftCatch = id,
+          expect_bot_combination = \t u v w -> or [t, u, v, w]
+        }
+
+testStrictPairMethods ::
+  forall writer m.
+  (Monad m, Monad (writer String m)) =>
+  String ->
+  (forall a. m a -> a) ->
+  WriterBaseF writer ->
+  WriterMethods writer ->
+  StrictPairMethodsExpectations ->
+  [TestTree]
+testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
+  [ testProperty
+      (prop_name "execWriter")
+      ( \(Bot v :: (Bot ((), String))) ->
+          let result = runW $ writerF $ return @m v
+           in isBottom result === expect_bot_execWriter (isBottom v)
       ),
-    testFunction
-      "tell"
-      -- NOTE: tell involves no binding so result is the same as lazy.
-      (\(Bot v :: (Bot String)) -> test_strictness_strict False $ Strict.tell v)
-      (\(Bot v :: (Bot String)) -> test_strictness_lazy False $ Lazy.tell v)
-      (\(Bot v :: (Bot String)) -> test_strictness_cps (isBottom v) $ CPS.tell v),
-    testFunction
-      "tellIO"
-      -- NOTE: tell involves no binding so result is the same as lazy.
-      (\(Bot v :: (Bot String)) -> test_strictness_strict_IO False $ Strict.tell v)
-      (\(Bot v :: (Bot String)) -> test_strictness_lazy_IO False $ Lazy.tell v)
-      (\(Bot v :: (Bot String)) -> test_strictness_cps_IO (isBottom v) $ CPS.tell v),
-    testFunction
-      "listen"
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.listen $ Strict.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.listen $ Lazy.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.listen $ CPS.writer v),
-    testFunction
-      "listenIO"
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.listen $ Strict.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.listen $ Lazy.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.listen $ CPS.writer v),
-    testFunction
-      "listens"
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.listens id $ Strict.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.listens id $ Lazy.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.listens id $ CPS.writer v),
-    testFunction
-      "listensIO"
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.listens id $ Strict.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.listens id $ Lazy.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.listens id $ CPS.writer v),
-    testFunction
-      "pass"
-      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_strict (isBottom v) $ Strict.pass $ return v)
-      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_lazy False $ Lazy.pass $ return v)
-      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_cps (isBottom v) $ CPS.pass $ return v),
-    testFunction
-      "censor"
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.censor id $ Strict.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.censor id $ Lazy.writer v)
-      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.censor id $ CPS.writer v)
+    testProperty
+      (prop_name "mapWriter - Identity")
+      ( \(Bot v :: (Bot ((), String))) ->
+          let result = runIdentity $ runWriterF $ mapWriter f $ writerF $ returnM v
+              f = Identity . runMonad
+           in isBottom result === expect_bot_mapWriter (isBottom v)
+      ),
+    testProperty
+      (prop_name "mapWriter - Maybe")
+      ( \(Bot v :: (Bot ((), String))) ->
+          let result = fromMaybe ((), "_") $ runWriterF $ mapWriter f $ writerF $ returnM v
+              f = Just . runMonad
+           in isBottom result === expect_bot_mapWriter (isBottom v)
+      ),
+    testProperty
+      (prop_name "tell")
+      ( \(Bot v :: (Bot String)) ->
+          test_pair_strictness_monad runW (expect_bot_tell (isBottom v)) $
+            tell v
+      ),
+    testProperty
+      (prop_name "listen")
+      ( \(Bot v :: (Bot ((), String))) ->
+          test_pair_strictness_monad runW (expect_bot_listen (isBottom v)) $
+            listen $
+              writerF $
+                returnM v
+      ),
+    testProperty
+      (prop_name "pass")
+      ( \(Bot v :: (Bot ((), F1 String String))) ->
+          let v' = coerce v :: ((), String -> String)
+           in test_pair_strictness_monad runW (expect_bot_pass (isBottom v)) $
+                pass $
+                  writerF $
+                    return (v', "")
+      ),
+    testProperty
+      (prop_name "censor")
+      ( \(Bot v :: (Bot ((), String))) ->
+          test_pair_strictness_monad runW (expect_bot_censor (isBottom v)) $
+            censor copyMonoid $
+              writerF $
+                returnM v
+      ),
+    testProperty
+      (prop_name "liftCallCC")
+      (label "TODO" $ property ()),
+    testProperty
+      (prop_name "liftCatch")
+      (label "TODO" $ property ()),
+    testProperty
+      (prop_name "combination")
+      ( \(Bot t :: (Bot (Int, String)))
+         (Bot u :: (Bot (Int, String)))
+         (Bot v :: (Bot (Int, String)))
+         (Bot w :: (Bot (Int, String))) ->
+            let mt = writerF $ returnM t
+                mu = writerF $ returnM u
+                mv = writerF $ returnM v
+                mw = writerF $ returnM w
+                result = do
+                  a <- mt
+                  (b, x) <- listen mu
+                  tell x
+                  c <- censor (drop 0) mv
+                  d <- mapWriter id mw
+                  return $ a + b + c + d
+                expected = expect_bot_combination (isBottom t) (isBottom u) (isBottom v) (isBottom w)
+             in isBottom (runW result) === expected
+      )
   ]
-    -- Type classes
-    ++ [ testFunction
-           "Functor"
-           (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ (\w -> w <> w) <$> Strict.writer v)
-           (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ (\w -> w <> w) <$> Lazy.writer v)
-           (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ (\w -> w <> w) <$> CPS.writer v),
-         testFunction
-           "Applicative map"
-           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
-               let mapper =
-                     if isBottom u
-                       then
-                         Strict.writer bottom
-                       else
-                         Strict.writer (id, "")
-               test_strictness_strict_IO (isBottom v || isBottom u) $ mapper <*> Strict.writer v
-           )
-           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
-               let mapper =
-                     if isBottom u
-                       then
-                         Lazy.writer bottom
-                       else
-                         Lazy.writer (id, "")
-               test_strictness_lazy_IO False $ mapper <*> Lazy.writer v
-           )
-           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
-               let mapper =
-                     if isBottom u
-                       then
-                         CPS.writer bottom
-                       else
-                         CPS.writer (id, "")
-               test_strictness_cps_IO (isBottom v || isBottom u) $ mapper <*> CPS.writer v
-           ),
-         testFunction
-           "Monad bind"
-           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v || isBottom w) $ Strict.writer v >>= \_ -> Strict.writer w)
-           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.writer v >>= \_ -> Lazy.writer w)
-           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v || isBottom w) $ CPS.writer v >>= \_ -> CPS.writer w),
-         -- TODO
-         -- Foldable
-         -- Traversable
-         -- MonadFix
-         -- MonadFail
-         -- MonadPlus
-         -- MonadIO
-         -- MonadZip
-         -- MonadTrans
-         testFunction
-           ""
-           (True === True)
-           (True === True)
-           (True === True),
-         testFunction
-           "Alternative"
-           -- TODO: why does this only depend on v?
-           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.writer v <|> Strict.writer w)
-           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_lazy_IO (isBottom v) $ Lazy.writer v <|> Lazy.writer w)
-           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.writer v <|> CPS.writer w),
-         testGroup
-           "Contravariant"
-           [ testProperty
-               "strict"
-               ( \(Bot v :: (Bot (Int, String))) -> do
-                   let writer = Strict.WriterT $ Predicate (== (1, ""))
-                   isBottom (getPredicate (Strict.runWriterT $ contramap (+ 2) writer) v)
-                     === isBottom v
-               ),
-             testProperty
-               "lazy"
-               ( \(Bot v :: (Bot (Int, String))) -> do
-                   let writer = Lazy.WriterT $ Predicate (== (1, ""))
-                   -- TODO:
-                   isBottom (getPredicate (Lazy.runWriterT $ contramap (+ 2) writer) v)
-                     === isBottom v
-               )
-           ]
-       ]
+  where
+    prop_name methodName = "[" <> testLabel <> "] " <> methodName
+    runW :: (Monoid w) => writer w m a -> (a, w)
+    runW = runMonad . runWriterF
+    returnM :: (a, w) -> m (a, w)
+    returnM = return @m
 
-testFunction :: (Testable a) => String -> a -> a -> a -> TestTree
-testFunction name strict lazy cps =
-  testGroup
-    name
-    [ testProperty "strict" strict,
-      testProperty "lazy" lazy,
-      testProperty "cps" cps
-    ]
+copyMonoid :: (Monoid w) => w -> w
+copyMonoid w = w <> w
 
-test_strictness_monad :: forall k writer w (m :: k) a. (writer w m a -> (a, w)) -> Bool -> writer w m a -> Property
-test_strictness_monad runW True writer =
-  assertExceptionIO @ErrorCall (const True) (evaluate $ runW writer)
-test_strictness_monad runW False writer =
-  monadicIO $ run $ runW writer `seq` return ()
+const2 :: a -> b -> c -> a
+const2 = const . const
 
-test_strictness_IO :: (writer w IO a -> IO (a, w)) -> Bool -> writer w IO a -> Property
-test_strictness_IO runW True writer =
-  assertExceptionIO @ErrorCall (const True) (runW writer)
-test_strictness_IO runW False writer = monadicIO $ run $ do
-  v <- runW writer
-  v `seq` return ()
+testStrictPairTypeClass ::
+  forall writer.
+  ( Traversable (writer String []),
+    Contravariant (writer String (Op (Int, String))),
+    MonadZip (writer String Identity)
+  ) =>
+  String ->
+  WriterBase writer ->
+  StrictPairTypeClassExpectations ->
+  [TestTree]
+testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectations {..} =
+  [ testProperty
+      (prop_name "foldMap")
+      ( \(v :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)]
+              result = getSum $ foldMap (const (Sum (0 :: Int))) (writer v')
+           in isBottom result === expect_bot_foldMap (any isBottom v)
+      ),
+    testProperty
+      (prop_name "traverse")
+      ( \(v :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)]
+              result = traverse Just (writer v')
+           in isBottom (isBottom result) === expect_bot_foldMap (any isBottom v)
+      ),
+    testProperty
+      (prop_name "contramap")
+      ( \(Bot v :: (Bot (Int, String))) ->
+          let f = getOp $ runWriter $ contramap (+ 1) $ writer (Op id)
+           in isBottom (f v) === expect_bot_contramap (isBottom v)
+      ),
+    testProperty
+      (prop_name "mzipWith")
+      ( \(Bot v :: (Bot (Int, String)))
+         (Bot w :: (Bot (Int, String))) ->
+            let f = runWriter $ mzipWith (+) (writer (Identity v)) (writer (Identity w))
+             in isBottom f === expect_bot_mzipWith (isBottom v) (isBottom w)
+      )
+  ]
+  where
+    prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
-test_strictness_lazy :: Bool -> Lazy.Writer w a -> Property
-test_strictness_lazy = test_strictness_monad Lazy.runWriter
+testStrictPairMonadic ::
+  forall writer.
+  ( MonadFix (writer String Maybe),
+    MonadPlus (writer String []),
+    MonadPlus (writer String Maybe),
+    MonadTrans (writer String),
+    MonadIO (writer String IO)
+  ) =>
+  String ->
+  WriterBaseF writer ->
+  StrictPairMonadicExpectations ->
+  [TestTree]
+testStrictPairMonadic testLabel WriterBaseF {..} StrictPairMonadicExpectations {..} =
+  [ testProperty
+      (prop_name "Functor fmap")
+      ( \(Bot v :: (Bot ((), String))) ->
+          let expected = expect_bot_functor_fmap (isBottom v)
+           in test_pair_strictness_monad runWriterF expected $
+                (\w -> w <> w) <$> writerF (Identity v)
+      ),
+    testProperty
+      (prop_name "Monad >>=")
+      ( \(Bot v :: (Bot (Int, String)))
+         (Bot w :: (Bot ((), String))) -> do
+            let expected = expect_bot_monad_bind (isBottom v) (isBottom w)
+             in test_pair_strictness_monad runWriterF expected $
+                  writerF (Identity v) >>= const (writerF (Identity w))
+      ),
+    testProperty
+      (prop_name "Applicative <*>")
+      ( \(Bot v :: (Bot ((), String)))
+         (Bot u :: (Bot (F1 () (), String))) -> do
+            let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
+                u' :: (() -> (), String)
+                u' = coerce u
+             in test_pair_strictness_monad runWriterF expected $
+                  writerF (Identity u') <*> writerF (Identity v)
+      ),
+    testProperty
+      (prop_name "Applicative liftA2")
+      ( \(Bot v :: (Bot (Int, String)))
+         (Bot u :: (Bot (Int, String))) -> do
+            let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
+            test_pair_strictness_monad runWriterF expected $
+              liftA2 (+) (writerF (Identity v)) (writerF (Identity u))
+      ),
+    testProperty
+      (prop_name "MonadFix mfix")
+      ( \(Bot v :: (Bot (Int, String))) ->
+          let expected = expect_bot_mfix (isBottom v)
+           in test_pair_strictness_monad (fromJust . runWriterF) expected $
+                mfix (const (writerF $ Just v))
+      ),
+    testProperty
+      (prop_name "Alternative <|> - []")
+      ( \(v :: [Bot (Int, String)])
+         (w :: [Bot (Int, String)]) ->
+            let v' = coerce v :: [(Int, String)]
+                w' = coerce w :: [(Int, String)]
+                result = runWriterF $ writerF v' <|> writerF w'
+                expected = expect_bot_alternative_list (isBottom <$> v') (isBottom <$> w')
+             in any isBottom result === expected
+      ),
+    testProperty
+      (prop_name "Alternative <|> - Maybe")
+      ( \(v :: Maybe (Bot (Int, String)))
+         (w :: Maybe (Bot (Int, String))) ->
+            let v' = coerce v :: Maybe (Int, String)
+                w' = coerce w :: Maybe (Int, String)
+                result = runWriterF $ writerF v' `mplus` writerF w'
+             in any isBottom result === expect_bot_alternative_maybe (isBottom <$> v') (isBottom <$> w')
+      ),
+    testProperty
+      (prop_name "MonadPlus mplus - []")
+      ( \(v :: [Bot (Int, String)])
+         (w :: [Bot (Int, String)]) ->
+            let v' = coerce v :: [(Int, String)]
+                w' = coerce w :: [(Int, String)]
+                result = runWriterF $ writerF v' `mplus` writerF w'
+                expected = expect_bot_alternative_list (isBottom <$> v') (isBottom <$> w')
+             in any isBottom result === expected
+      ),
+    testProperty
+      (prop_name "MonadTrans lift")
+      ( \(Bot v :: (Bot ())) ->
+          let expected = expect_bot_lift (isBottom v)
+           in test_pair_strictness_IO (runWriterF @String) expected $
+                lift (return v)
+      ),
+    testProperty
+      (prop_name "MonadIO liftIO")
+      ( \(Bot v :: (Bot ())) ->
+          let expected = expect_bot_lift (isBottom v)
+           in test_pair_strictness_IO (runWriterF @String) expected $
+                liftIO (return v)
+      ),
+    testProperty
+      (prop_name "Monad nested")
+      ( \(Bot v :: (Bot (Int, String)))
+         (Bot w :: (Bot (Int, String))) ->
+            let expected = expect_bot_nested (isBottom v) (isBottom w)
+                result :: ContT Int (ReaderT Int (writer String IO)) Int
+                result = do
+                  s <- lift $ lift $ writerF $ return v
+                  t <- lift ask
+                  u <-
+                    callCC
+                      ( \f -> do
+                          x <- f $ s + t
+                          f x
+                      )
+                  a <- lift $ lift $ writerF $ return w
+                  return $ u * a
+                q =
+                  let reader = runContT result return
+                   in runWriterF $ runReaderT reader 1
+             in test_pair_strictness_IO (runWriterF @String) expected $
+                  liftIO q
+      )
+  ]
+  where
+    prop_name methodName = "[" <> testLabel <> "]" <> methodName
 
-test_strictness_lazy_IO :: Bool -> Lazy.WriterT w IO a -> Property
-test_strictness_lazy_IO = test_strictness_IO Lazy.runWriterT
+test_pair_strictness_monad :: forall k writer w (m :: k) a b. (writer w m a -> b) -> Bool -> writer w m a -> Property
+test_pair_strictness_monad runW True wr =
+  assertExceptionIO @ErrorCall (const True) (evaluate $ runW wr)
+test_pair_strictness_monad runW False wr = monadicIO $ run $ runW wr `seq` return ()
 
-test_strictness_strict_IO :: Bool -> Strict.WriterT w IO a -> Property
-test_strictness_strict_IO = test_strictness_IO Strict.runWriterT
-
-test_strictness_cps_IO :: (Monoid w) => Bool -> CPS.WriterT w IO a -> Property
-test_strictness_cps_IO = test_strictness_IO CPS.runWriterT
-
-test_strictness_strict :: Bool -> Strict.Writer w a -> Property
-test_strictness_strict = test_strictness_monad Strict.runWriter
-
-test_strictness_cps :: (Monoid w) => Bool -> CPS.Writer w a -> Property
-test_strictness_cps = test_strictness_monad CPS.runWriter
+test_pair_strictness_IO :: (writer w IO a -> IO b) -> Bool -> writer w IO a -> Property
+test_pair_strictness_IO runW True wr =
+  assertExceptionIO @ErrorCall (const True) (runW wr)
+test_pair_strictness_IO runW False wr = monadicIO $ run $ (`seq` ()) <$> runW wr

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -9,14 +10,8 @@ module WriterStrictness (test) where
 import           Arbitrary
 
 import           Control.Applicative
-import           Control.Arrow (Arrow (second), first)
 import           Control.Exception (ErrorCall (..), evaluate)
 import           Control.Exception.Base (displayException)
-import           Control.Monad
-import           Control.Monad.Fix
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Cont (ContT (..), callCC, runContT)
-import           Control.Monad.Trans.Reader (ReaderT (..), ask, reader)
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
@@ -30,671 +25,335 @@ import           Data.Monoid
 
 import           Test.ChasingBottoms.IsBottom (isBottom)
 import           Test.QuickCheck
-import           Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
+import           Test.QuickCheck.Monadic (assertExceptionIO)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 test :: IO ()
 test = defaultMain $ testGroup "Writer" strictSpineTest
 
+-- | Monoid choice
+--
+-- For the test, we use a monoid that is strict in both arguments of mappend :: a -> a -> a
+--
+-- This is needed in particular to test a strictness property of the CPS writer, which
+-- is that it evaluates the log w strictly as it is accumulated.
+-- If mappend is lazy in an argument, then outwardly the result appears the same with or without evaluation
+-- and hence cannot be validated.
+-- e.g.
+--   List mappend is only strict in the first argument:
+--     writer ((), _|_) >> writer ((), "a")      _|_
+--     writer ((), "a") >> writer ((), _|_)      ((), ('a':_|_))
+--
+--   Sum mappend is strict in both:
+--     writer ((), Sum 0) >> writer ((), _|_)    _|_
+--     writer ((), _|_) >> writer ((), Sum 0)    _|_
+type SumInt = Sum Int
+
 -- | Strictness test
 --
---  TODO: documentation
+-- Each writer variation is strict in the following ways:
 --
---  TODO: CPS
+--  Writer.Lazy     non-strict in spine (a,w)
+--
+--  Writer.Strict   strict in spine (a,w)
+--
+--  Writer.CPS      strict in spine (a,w) and log w
 --
 strictSpineTest :: [TestTree]
 strictSpineTest = [
   testGroup "writer" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p,
-      testProperty "Strict" $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p,
-      testProperty "CPS"    $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeep p)
+      testProperty "Lazy"   $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p,
+      testProperty "Strict" $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p,
+      testProperty "CPS"    $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p)
   ],
 
- -- TODO: 
+  -- Lazy, Strict Writer    output of map is used directly without any intervention by the Writer itself
+  --                        i.e. spine strict
+  --
+  -- CPS Writer             output of map is evaluated in the log w
   testGroup "mapWriter" [
-      testProperty "Lazy - lazy map"    $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT idLazy $ Lazy.WriterT $ return p,
-      testProperty "Lazy - strict map"  $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.WriterT $ return p,
-
-      testProperty "Strict - lazy map"  $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT idLazy $ Strict.WriterT $ return p,
-      testProperty "Strict - strict map"$ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.WriterT $ return p,
-
-      testProperty "CPS - lazy map"     $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT idLazy $ CPS.writer (unBotDeep p),
-      testProperty "CPS - strict map"   $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer (unBotDeep p)
+      testProperty "Lazy" $ \m (f  :: F1Bot ((), SumInt) ((), SumInt)) ->
+        let f' = unF1Bot f
+            result = f' ((), mempty)
+        in isStrictIn result $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT (f'<$>) $ pure (),
+      testProperty "Strict" $ \m (f  :: F1Bot ((), SumInt) ((), SumInt)) ->
+        let f' = unF1Bot f
+            result = f' ((), mempty)
+        in isStrictIn result $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT (f'<$>) $ pure (),
+      testProperty "CPS" $ \m (f  :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+        let f' = coerce f :: ((), SumInt) -> ((), SumInt)
+            result = f' ((), mempty)
+        in isBiStrictIn result (snd result) $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT (f'<$>) $ pure ()
   ],
 
   testGroup "listen" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Float, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (Bot (p :: (Float, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (p :: Bot (Float, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeep p)
+      testProperty "Lazy"   $ \m (Bot (p :: (Float, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return p,
+      testProperty "Strict" $ \m (Bot (p :: (Float, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (p :: Bot (Float, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeeper p)
   ],
 
   testGroup "listens" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Float, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.writer p,
-      testProperty "Strict" $ \m (Bot (p :: (Float, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.writer p,
-      testProperty "CPS"    $ \m (p :: Bot (Float, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeep p)
+      testProperty "Lazy"   $ \m (Bot (p :: (Float, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ return p,
+      testProperty "Strict" $ \m (Bot (p :: (Float, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (p :: Bot (Float, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeeper p)
   ],
 
   testGroup "tell" [
-      testProperty "Lazy"   $ \(m, Bot (w :: String)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.tell w,
-      testProperty "Strict" $ \(m, Bot (w :: String)) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.tell w,
-      testProperty "CPS"    $ \(m, Bot (w :: String)) -> isStrict w $ withBaseMonad m $ CPS.runWriterT $ CPS.tell w
+      testProperty "Lazy"   $ \(m, Bot (w :: SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.tell w,
+      testProperty "Strict" $ \(m, Bot (w :: SumInt)) -> isLazy $ withBaseMonad m $ Strict.runWriterT $ Strict.tell w,
+      testProperty "CPS"    $ \(m, Bot (w :: SumInt)) -> isStrictIn w $ withBaseMonad m $ CPS.runWriterT $ CPS.tell w
   ],
 
-  -- TODO: revisit function
-  testGroup "pass" [
-      testProperty "Lazy"   $ \m (p :: Bot ((), Bot String)) ->
-        let p' = p `seq` second (<>) $ unBotDeep p
-        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ return p',
-      testProperty "Strict" $ \m (p :: Bot ((), Bot String)) ->
-        let p' = p `seq` second (<>) $ unBotDeep p
-        in isStrict p' $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ return p',
-      testProperty "CPS"    $ \m (p :: Bot ((), Bot String)) ->
-        let p' = p `seq` second (<>) $ unBotDeep p
-        in isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ return p'
-  ],
-
-  -- NOTE: TODO note on Sum Int
+  -- There are 3 levels of strictness to test:
+  -- 1) spine (a, w)
+  -- 2) log w
+  -- 3) log map w -> w
+  --
+  -- Lazy, Strict Writers are only concerned with 1.
+  -- CPS Writer is strict in all.
   testGroup "censor" [
-      testProperty "Lazy"   $ \m (Bot (w :: Sum Int)) (Bot (p :: ((), Sum Int))) ->
+      testProperty "Lazy"   $ \m (Bot (w :: SumInt)) (Bot (p :: ((), SumInt))) ->
         isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor (<> w) $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (Bot (w :: Sum Int)) (Bot (p :: ((), Sum Int))) ->
-        isStrict p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor (<> w) $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (Bot (w :: Sum Int)) (p :: Bot ((), Bot (Sum Int))) ->
-        isDeepStrict1 p w $ withBaseMonad m $ CPS.runWriterT $ CPS.censor (<> w) $ CPS.writer (unBotDeep p)
+      testProperty "Strict" $ \m (Bot (w :: SumInt)) (Bot (p :: ((), SumInt))) ->
+        isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor (<> w) $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (Bot (w :: SumInt)) (p :: Bot ((), Bot SumInt)) ->
+        isStrictDeeperInWith p w $ withBaseMonad m $ CPS.runWriterT $ CPS.censor (<> w) $ CPS.writer (unBotDeeper p)
   ],
 
+  -- See note on censor above.
+  testGroup "pass" [
+      testProperty "Lazy"   $ \m (p :: Bot (((), F1 SumInt SumInt), SumInt)) ->
+        let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
+        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ return p',
+      testProperty "Strict"   $ \m (p :: Bot (((), F1 SumInt SumInt), SumInt)) ->
+        let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
+        in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ return p',
+      testProperty "CPS"    $ \m (p :: Bot (((), F1Bot SumInt SumInt), Bot SumInt)) ->
+        let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
+            v  = (snd $ fst p') mempty
+        in isStrictDeeperInWith p v $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer p'
+  ],
 
   -- == Functor/Applicative/Monad ==
   testGroup "Functor: fmap" [
-      testProperty "Lazy"    $ \m (Bot (p :: (Int, String))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return p),
-      testProperty "Strict"  $ \m (Bot (p :: (Int, String))) -> isStrict p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return p),
-      testProperty "CPS"     $ \m (p :: Bot (Int, Bot String)) -> isDeepStrict p $ withBaseMonad m $ CPS.runWriterT $ (+1) <$> CPS.writer (unBotDeep p)
+      testProperty "Lazy"    $ \m (Bot (p :: (Int, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return p),
+      testProperty "Strict"  $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return p),
+      testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ (+1) <$> CPS.writer (unBotDeeper p)
     ],
 
   testGroup "Applicative: <*>" [
-      testProperty "Lazy"    $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
-          let f' = coerce wf :: (() -> (), String)
+      testProperty "Lazy"    $ \m (Bot (wf :: (F1 () (), SumInt))) (Bot (p :: ((), SumInt))) ->
+          let f' = coerce wf :: (() -> (), SumInt)
          in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer p ,
-      testProperty "Strict"  $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
-          let f' = coerce wf :: (() -> (), String)
-         in isStrict2 p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer p,
-      testProperty "CPS"     $ \m (Bot (p :: ((), String))) (Bot (wf :: (F1 () (), String))) ->
-          let f' = coerce wf :: (() -> (), String)
-         in isStrict2 p wf $ withBaseMonad m $ CPS.runWriterT $ CPS.writer f' <*> CPS.writer p
+      testProperty "Strict"  $ \m(Bot (wf :: (F1 () (), SumInt))) (Bot (p :: ((), SumInt))) ->
+          let f' = coerce wf :: (() -> (), SumInt)
+         in isBiStrictIn p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer p,
+      testProperty "CPS"     $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+          let f' = coerce wf :: (() -> (), SumInt)
+         in isBiStrictDeeperIn p wf $ withBaseMonad m $ CPS.runWriterT $ CPS.writer f' <*> CPS.writer (unBotDeeper p)
     ],
 
-  -- NOTE: TODO note on Sum Int
   testGroup "Applicative: liftA2" [
-      testProperty "Lazy"    $ \m (Bot (p :: (Int, Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+      testProperty "Lazy"    $ \m (Bot (p :: (Int, SumInt))) (Bot (q :: (Int, SumInt))) ->
           isLazy $ withBaseMonad m $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer p) (Lazy.writer q),
-      testProperty "Strict"  $ \m (Bot (p :: (Int, Sum Int))) (Bot (q :: (Int, Sum Int))) ->
-          isStrict2 p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer p) (Strict.writer q),
-      testProperty "CPS"     $ \m (p :: Bot (Int, Bot (Sum Int))) (q :: Bot (Int, Bot (Sum Int))) ->
-          isDeepStrict2 p q $ withBaseMonad m $ CPS.runWriterT $ liftA2 (+) (CPS.writer $ unBotDeep p) (CPS.writer $ unBotDeep q)
+      testProperty "Strict"  $ \m (Bot (p :: (Int, SumInt))) (Bot (q :: (Int, SumInt))) ->
+          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer p) (Strict.writer q),
+      testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ liftA2 (+) (CPS.writer $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
     ],
 
-  -- NOTE: TODO note on Sum Int
   testGroup "Monad: >>=" [
-      testProperty "Lazy"        $ \m (Bot (p :: ((), Sum Int))) (Bot (q :: (Int, Sum Int))) ->
+      testProperty "Lazy"        $ \m (Bot (p :: ((), SumInt))) (Bot (q :: (Int, SumInt))) ->
           isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p >>= const (Lazy.writer q),
-      testProperty "Strict"      $ \m (Bot (p :: ((), Sum Int))) (Bot (q :: (Int, Sum Int))) ->
-          isStrict2 p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p >>= const (Strict.writer q),
-      testProperty "CPS"         $ \m (p :: Bot ((), Bot (Sum Int))) (q :: Bot (Int, Bot (Sum Int))) ->
-          isDeepStrict2 p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeep p) >>= const (CPS.writer (unBotDeep q))
+      testProperty "Strict"      $ \m (Bot (p :: ((), SumInt))) (Bot (q :: (Int, SumInt))) ->
+          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p >>= const (Strict.writer q),
+      testProperty "CPS"         $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
 
-  -- TODO
-  testGroup "Alternative: <|>" [
-      testProperty "Lazy"      $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p
-              q' = unBot <$> q
-           -- same as underlying alternative, so non-strict
-           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT p' <|> Lazy.WriterT q')) === (isBottom <$> p' ++ q'),
-      testProperty "Strict"   $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p 
-              q' = unBot <$> q
-           in (isBottom <$> Strict.runWriterT (Strict.WriterT p' <|> Strict.WriterT q')) === (isBottom <$> p' ++ q'),
-      testProperty "CPS"      $ \(p :: [Bot (Int, Bot String)]) (q :: [Bot (Int, Bot String)]) ->
-          let p' = unBotDeep <$> p
-              q' = unBotDeep <$> q
-           in (isBottom <$> CPS.runWriterT (CPS.writerT p' <|> CPS.writerT q')) === (isBottomDeep <$> p ++ q)
-    ],
 
-  -- TODO
-  testGroup "MonadPlus: mplus" [
-      testProperty "Lazy"      $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p
-              q' = unBot <$> q
-           -- same as underlying alternative, so non-strict
-           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT p' `mplus` Lazy.WriterT q')) === (isBottom <$> p' ++ q'),
-      testProperty "Strict"   $ \(p :: [Bot (Int, String)]) (q :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p
-              q' = unBot <$> q 
-           in (isBottom <$> Strict.runWriterT (Strict.WriterT p' `mplus` Strict.WriterT q')) === (isBottom <$> p' ++ q'),
-      testProperty "CPS"      $ \(p :: [Bot (Int, Bot String)]) (q :: [Bot (Int, Bot String)]) ->
-          let p' = unBotDeep <$> p
-              q' = unBotDeep <$> q
-           in (isBottom <$> CPS.runWriterT (CPS.writerT p' `mplus` CPS.writerT q')) === (isBottomDeep <$> p ++ q)
-    ],
-
-  testGroup "MonadFix: >>=" [
-      -- NOTE: implementation of any fixed point functions must be lazy, so
-      -- mfix is lazy for all Writer types.
-      testProperty "Lazy" $ \(Bot (w :: String)) ->
-          isStrict w $ Lazy.runWriterT $ mfix (\x -> Lazy.writer $ w `seq` (w, x)),
-      testProperty "Strict" $ \(Bot (w :: String)) ->
-          isStrict w $ Strict.runWriterT $ mfix (\x -> Strict.writer $ w `seq` (w, x)),
-
-      -- TODO:
-      testProperty "CPS"    $ \(p :: Bot (Int, Bot String)) ->
-          isDeepStrict p $ CPS.runWriterT $ mfix (\x -> CPS.writer $ p `seq` first (x +) (unBotDeep p))
-    ],
-
-  -- TODO
-  testGroup "MonadStack" [
-    testProperty "Lazy" $
-       \(Bot (p :: (Int, String)))
-         (Bot (q :: (Int, String)))
-         ->
-            let
-                result :: TestMonadStack String (Lazy.WriterT String IO) Int
-                result = do
-                  q' <- lift $ lift $ Lazy.WriterT $ return q
-                  a <- lift ask
-                  b <- callCC $ \next -> do
-                    when (even a) $ next (10 :: Int)
-                    return 20
-                  p' <- lift $ lift $ Lazy.WriterT $ return p
-                  lift $ lift $ Lazy.tell "hello"
-                  return $ q' + a + p' + b
-                writer = Lazy.censor (filter (/= 'l')) $ runTestMonadStack result show
-             in isLazy $ Lazy.runWriterT writer,
-    testProperty "Strict" $
-       \(Bot (p :: (Int, String)))
-         (Bot (q :: (Int, String)))
-         ->
-            let
-                result :: TestMonadStack String (Strict.WriterT String IO) Int
-                result = do
-                  q' <- lift $ lift $ Strict.WriterT $ return q
-                  a <- lift ask
-                  b <- callCC $ \next -> do
-                    when (even a) $ next (10 :: Int)
-                    return 20
-                  p' <- lift $ lift $ Strict.WriterT $ return p
-                  lift $ lift $ Strict.tell "hello"
-                  return $ q' + a + p' + b
-                writer = Strict.censor (filter (/= 'l')) $ runTestMonadStack result show
-             in isStrict2 p q $ Strict.runWriterT writer
-  ],
-
-
-  -- == Other type classes ==
+  -- == Other typeclasses ==
   testGroup "Foldable: foldMap" [
-      -- NOTE: foldMap is lazy in both Lazy and Strict Writers due to the use of fst to pick the value.
-      testProperty "Lazy"    $ \(p :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT p'),
-      testProperty "Strict"  $ \(p :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT p')
+      -- NOTE: foldMap is lazy for both Writers, since it only involves the value `a` of Writer w m a.
+      testProperty "Lazy"    $ \(p :: [Bot (Int, SumInt)]) ->
+          let p' = unBot <$> p
+          in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT p'),
+      testProperty "Strict"  $ \(p :: [Bot (Int, SumInt)]) ->
+          let p' = unBot <$> p
+          in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT p')
+
       -- NOTE: no Foldable for CPS
   ],
 
   testGroup "Traversable: traverse" [
-      -- NOTE: traverse
-      testProperty "Lazy"    $ \(p :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p in isStrictAny p' $ evaluate $ traverse Just (Lazy.WriterT p'),
-      testProperty "Strict"  $ \(p :: [Bot (Int, String)]) ->
-          let p' = unBot <$> p in isStrictAny p' $ evaluate $ traverse Just (Strict.WriterT p')
+      testProperty "Lazy"    $ \(p :: [Bot (Int, SumInt)]) ->
+          let p' = unBot <$> p
+              result = traverse Identity (Lazy.WriterT p')
+          in (isBottom <$> p') === (isBottom <$> Lazy.runWriterT (runIdentity result)),
+      testProperty "Strict"  $ \(p :: [Bot (Int, SumInt)]) ->
+          let p' = unBot <$> p
+              result = traverse Identity (Strict.WriterT p')
+          in (isBottom <$> p') === (isBottom <$> Strict.runWriterT (runIdentity result))
+
       -- NOTE: no Traversable for CPS
   ],
 
   testGroup "MonadZip: mzipWith" [
       testProperty "Lazy"  $
-        \(Bot (p :: (Int, String)))
-         (Bot (q :: (Int, String))) ->
-            isLazyValue $ evaluate $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
+        \(Bot (p :: (Int, SumInt)))
+         (Bot (q :: (Int, SumInt))) ->
+           isLazyValue $ evaluate $ Lazy.runWriterT $ mzipWith (+) (Lazy.WriterT (Identity p)) (Lazy.WriterT (Identity q)),
       testProperty "Strict"  $
-        \(Bot (p :: (Int, String)))
-         (Bot (q :: (Int, String))) ->
-           isStrict2 p q $ evaluate $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
+        \(Bot (p :: (Int, SumInt)))
+         (Bot (q :: (Int, SumInt))) ->
+           isBiStrictIn p q $ evaluate $ Strict.runWriterT $ mzipWith (+) (Strict.WriterT (Identity p)) (Strict.WriterT (Identity q))
       -- NOTE: no MonadZip for CPS
   ],
 
   testGroup "Contravariant: contramap" [
-      testProperty "Lazy"   $ \(Bot (p :: (Int, String))) -> 
-        let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id) in isLazyValue $ f p,
-      testProperty "Strict" $ \(Bot (p :: (Int, String))) -> 
-        let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id) in isStrictValue p $ f p
-      -- NOTE: no MonadZip for CPS
+      testProperty "Lazy"   $ \(Bot (p :: (Int, SumInt))) ->
+        let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id)
+        in isLazyValue $ f p,
+      testProperty "Strict" $ \(Bot (p :: (Int, SumInt))) ->
+        let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id)
+        in isStrictValue p $ f p
+      -- NOTE: no Contravariant for CPS
   ],
 
-  -- TODO
   testGroup "combination" [
      testProperty "Lazy" $
        \ m
-         (Bot (t :: (Int, String)))
-         (Bot (u :: (Int, String)))
-         (Bot (v :: (Int, String)))
-         (Bot (w :: (Int, String))) ->
+         (f :: F1Bot (Int, SumInt) (Int, SumInt))
+         (Bot (r :: SumInt))
+         (Bot (s :: SumInt))
+         (Bot (t :: (Int, SumInt)))
+         (Bot (u :: (Int, SumInt)))
+         (Bot (v :: (Int, SumInt))) ->
            isLazy $ withBaseMonad m $ Lazy.runWriterT $ do
-                a <- Lazy.WriterT (return t)
-                (b, x) <- Lazy.listen $ Lazy.WriterT $ return u
-                Lazy.tell x
-                c <- Lazy.censor (drop 0) $ Lazy.WriterT $ return v
-                d <- Lazy.mapWriterT id $ Lazy.WriterT $ return w
-                return $ a + b + c + d,
+             a <- Lazy.WriterT (return t)
+             (b, x) <- Lazy.listen $ Lazy.WriterT $ return u
+             Lazy.tell $ s <> x
+             c <- Lazy.censor (<>r) $ Lazy.WriterT $ return v
+             d <- Lazy.mapWriterT (unF1Bot f<$>) $ pure 0
+             return $ a + b + c + d,
+
      testProperty "Strict" $
        \ m
-         (Bot (t :: (Int, String)))
-         (Bot (u :: (Int, String)))
-         (Bot (v :: (Int, String)))
-         (Bot (w :: (Int, String)))
-         (s :: String) ->
-           let expected = isBottom t || isBottom u || isBottom v || isBottom w
+         (f :: F1Bot (Int, SumInt) (Int, SumInt))
+         (Bot (r :: SumInt))
+         (Bot (s :: SumInt))
+         (Bot (t :: (Int, SumInt)))
+         (Bot (u :: (Int, SumInt)))
+         (Bot (v :: (Int, SumInt))) ->
+           let
+             f' = unF1Bot f
+             expected = isBottom t || isBottom u || isBottom v
+              || isBottom (f' (0, mempty))
            in shouldBeBottom expected $ withBaseMonad m $ Strict.runWriterT $ do
-                a <- Strict.WriterT (return t)
-                (b, x) <- Strict.listen $ Strict.WriterT $ return u
-                Strict.tell (s ++ x)
-                c <- Strict.censor (drop 0) $ Strict.WriterT $ return v
-                d <- Strict.mapWriterT id $ Strict.WriterT $ return w
-                return $ a + b + c + d,
+             a <- Strict.WriterT (return t)
+             (b, x) <- Strict.listen $ Strict.WriterT $ return u
+             Strict.tell $ s <> x
+             c <- Strict.censor (<> r) $ Strict.WriterT $ return v
+             d <- Strict.mapWriterT (f'<$>) $ pure 0
+             return $ a + b + c + d,
+
      testProperty "CPS" $
        \ m
-         (t :: Bot ((), Bot (Sum Int)))
-         (u :: Bot ((), Bot (Sum Int)))
-         (v :: Bot ((), Bot (Sum Int)))
-         (w :: Bot ((), Bot (Sum Int)))
-         (Bot (s :: (Sum Int))) ->
-           let expected = isBottomDeep t || isBottomDeep u || isBottomDeep v || isBottomDeep w || isBottom s
-               result =  withBaseMonad m $ CPS.runWriterT $ do
-                a <- CPS.writer $ unBotDeep t
-                (b, x) <- CPS.listen $ CPS.writer $ unBotDeep u
-                c <- CPS.censor id $ CPS.writer $ unBotDeep v
-                d <- CPS.mapWriterT id $ CPS.writer $ unBotDeep w
-                -- CPS.tell $ show $ a <> b <> c <> d
-                CPS.tell $ x <> s
-                return $ a <> b <> c <> d
-           in shouldBeBottom expected result
+         (f :: F1Bot (Int, SumInt) (Int, Bot SumInt))
+         (Bot (r :: SumInt))
+         (Bot (s :: SumInt))
+         (t :: Bot (Int, Bot SumInt))
+         (u :: Bot (Int, Bot SumInt))
+         (v :: Bot (Int, Bot SumInt)) ->
+           let
+             f' = coerce f :: (Int, SumInt) -> (Int, SumInt)
+             expected = isBottomDeeper t || isBottomDeeper u || isBottomDeeper v
+              || isBottom s || isBottom r
+              || isBottom (f' (0, mempty)) || isBottom (snd $ f' (0, mempty))
+           in shouldBeBottom expected $ withBaseMonad m $ CPS.runWriterT $ do
+             a <- CPS.writer $ unBotDeeper t
+             (b, x) <- CPS.listen $ CPS.writer $ unBotDeeper u
+             CPS.tell $ s <> x
+             c <- CPS.censor (<>r) $ CPS.writer $ unBotDeeper v
+             d <- CPS.mapWriterT (f'<$>) $ pure 0
+             return $ a + b + c + d
+    ]
   ]
-  ]
-  where
-    idLazy :: Functor f => f (a, w) -> f (a, w)
-    idLazy = ((\ ~(a, w) -> (a, w)) <$>)
 
--- -- | Strictness tests for the value (a, w) of Writers
--- --
--- -- Test whether the pair (a, w) is handled lazily/strictly
--- -- in Writer functions as expected.
--- -- In particular, whether pairs patterns are handled correctly
--- -- in the respective Writers.
--- --
--- -- Please note that tests DO NOT test strictness in the log w
--- -- of the CPS writer.
--- --
--- strictPairTests :: [TestTree]
--- strictPairTests =
---     testStrictPairLifts
---       "Lazy"
---       lazyBaseF
---       lazyWriterLifts
---       StrictPairLiftsExpectations
---         { expect_bot_liftCatch = id  -- NOTE: same as strict since the value is just passed through.
---         }
---     ++ testStrictPairLifts
---       "Strict"
---       strictBaseF
---       strictWriterLifts
---       StrictPairLiftsExpectations
---         { expect_bot_liftCatch = id
---         }
---     ++ testStrictPairLifts
---       "CPS"
---       cpsBase
---       cpsWriterLifts
---       StrictPairLiftsExpectations
---         { expect_bot_liftCatch = id
---         }
+bottomLabel :: String
+bottomLabel = "_|_"
 
--- | Value (a, w) strictness tests for the core Writer methods.
---
--- Functions that do not involve handling pairs are not tested:
--- * tell
--- testStrictPairMethods ::
---   forall writer m.
---   (Monad m, Monad (writer String m)) =>
---   String ->
---   (forall a. m a -> a) ->
---   WriterBaseF writer ->
---   WriterMethods writer String m ->
---   StrictPairMethodsExpectations ->
---   [TestTree]
--- testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
---   [
-    -- testProperty
-    --   (prop_name "execWriter")
-    --   ( \(Bot v :: (Bot ((), String))) ->
-    --       let result = runMonad $ execWriterT $ writerF $ return @m v
-    --        in isBottom result === expect_bot_execWriter (isBottom v)
-    --   ),
+notBottomLabel :: String
+notBottomLabel = "Not _|_"
 
-    -- NOTE: strictness depends only on the strictness of the provided map
-    -- testProperty
-    --   (prop_name "mapWriter - strict map")
-    --   ( \(Bot v :: (Bot ((), String))) ->
-    --       let result = runIdentity $ runWriterF $ mapWriter fstrict $ writerF $ returnM v
-    --           fstrict = Identity . runMonad
-    --        in isBottom result === expect_bot_mapWriter_strict (isBottom v)
-    --   ),
-    -- testProperty
-    --   (prop_name "mapWriter - lazy map")
-    --   ( \(Bot v :: (Bot ((), String))) ->
-    --       let result = runWriterF $ mapWriter flazy $ writerF $ returnM v
-    --           flazy x = let ~(a, w) = runMonad x in Identity (a, w)
-    --        in isBottom result === expect_bot_mapWriter_lazy (isBottom v)
-    --   ),
-
-    -- -- NOTE: no test for tell since it does not involve pair values
-
-    -- testProperty
-    --   (prop_name "listen")
-    --   ( \(Bot v :: (Bot ((), String))) ->
-    --       test_pair_strictness_monad runW (expect_bot_listen (isBottom v)) $
-    --         listen $ writerF $ returnM v
-    --   ),
-    -- testProperty
-    --   (prop_name "pass")
-    --   ( \(Bot v :: (Bot ((), F1 String String))) ->
-    --       let p' = coerce v :: ((), String -> String)
-    --        in test_pair_strictness_monad runW (expect_bot_pass (isBottom v)) $
-    --             pass $
-    --               writerF $
-    --                 return (p', "")
-    --   ),
-    -- testProperty
-    --   (prop_name "censor")
-    --   ( \(Bot v :: (Bot ((), String))) ->
-    --       test_pair_strictness_monad runW (expect_bot_censor (isBottom v)) $
-    --         censor (\w -> w <> w) $
-    --           writerF $
-    --             returnM v
-    --   ),
-    -- testProperty
-    --   (prop_name "combination")
-    --   ( \(Bot t :: (Bot (Int, String)))
-    --      (Bot u :: (Bot (Int, String)))
-    --      (Bot v :: (Bot (Int, String)))
-    --      (Bot w :: (Bot (Int, String))) ->
-    --         let mt = writerF $ returnM t
-    --             mu = writerF $ returnM u
-    --             mv = writerF $ returnM v
-    --             mw = writerF $ returnM w
-    --             result = do
-    --               a <- mt
-    --               (b, x) <- listen mu
-    --               tell x
-    --               c <- censor (drop 0) mv
-    --               d <- mapWriter id mw
-    --               return $ a + b + c + d
-    --             expected = expect_bot_combination (isBottom t) (isBottom u) (isBottom v) (isBottom w)
-    --          in isBottom (runW result) === expected
-    --   )
-  -- ]
-  -- where
-    -- prop_name methodName = "[" <> testLabel <> "] " <> methodName
-    -- runW :: (Monoid w) => writer w m a -> (a, w)
-    -- runW = runMonad . runWriterF
-    -- returnM :: (a, w) -> m (a, w)
-    -- returnM = return @m
-
--- | Value (a, w) strictness tests for lifts.
---
--- In general, lifts do not involve pairs (a, w), since the log w is
--- not visible to other monads in the stack.
--- Hence, tests are omitted for:
--- * lift
--- * liftIO
--- * liftCallCC
---
--- testStrictPairLifts ::
---   forall writer.
---   String ->
---   WriterBaseF writer ->
---   WriterLifts writer ->
---   StrictPairLiftsExpectations ->
---   [TestTree]
--- testStrictPairLifts testLabel WriterBaseF {..} WriterLifts {..} StrictPairLiftsExpectations {..} =
---   [
---     testProperty
---       (prop_name "liftCatch - no error")
---       ( \(Bot v :: (Bot ((), String))) ->
---         let
---            catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
---            catch = liftCatch catchE
---            writer = catch (writerF $ return v) e
---         in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
---               $ fromRight e <$> runExceptT (runWriterF writer)
---       ),
---     testProperty
---       (prop_name "liftCatch - handle error")
---       ( \(Bot v :: (Bot ((), String))) ->
---         let
---            catch :: Catch SomeException (writer String (ExceptT SomeException IO)) ()
---            catch = liftCatch catchE
---            writer = catch (writerF $ throwE e) (const (writerF $ return v))
---         in test_pair_strictness_IOBase (expect_bot_liftCatch (isBottom v))
---               $ fromRight e <$> runExceptT (runWriterF writer)
---       )
---   ]
---   where
---     e = error "this should never happen"
---     prop_name methodName = "[" <> testLabel <> "] " <> methodName
-
--- | Value (a, w) strictness tests for type class functions other than Monads.
---
--- testStrictPairTypeClass ::
---   forall writer.
---   ( Traversable (writer String []),
---     Contravariant (writer String (Op (Int, String))),
---     MonadZip (writer String Identity)
---   ) =>
---   String ->
---   WriterBase writer ->
---   StrictPairTypeClassExpectations ->
---   [TestTree]
--- testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectations {..} =
---   [ testProperty
---       (prop_name "foldMap")
---       ( \(v :: [Bot (Int, String)]) ->
---           let p' = coerce v :: [(Int, String)]
---               result = getSum $ foldMap (const (Sum (0 :: Int))) (writer p')
---            in isBottom result === expect_bot_foldMap (any isBottom v)
---       ),
---     testProperty
---       (prop_name "traverse")
---       ( \(v :: [Bot (Int, String)]) ->
---           let p' = coerce v :: [(Int, String)]
---               result = traverse Just (writer p')
---            in isBottom (isBottom result) === expect_bot_foldMap (any isBottom v)
---       ),
---     testProperty
---       (prop_name "contramap")
---       ( \(Bot v :: (Bot (Int, String))) ->
---           let f = getOp $ runWriter $ contramap (+ 1) $ writer (Op id)
---            in isBottom (f v) === expect_bot_contramap (isBottom v)
---       ),
---     testProperty
---       (prop_name "mzipWith")
---       ( \(Bot v :: (Bot (Int, String)))
---          (Bot w :: (Bot (Int, String))) ->
---             let f = runWriter $ mzipWith (+) (writer (Identity v)) (writer (Identity w))
---              in isBottom f === expect_bot_mzipWith (isBottom v) (isBottom w)
---       )
---   ]
---   where
---     prop_name methodName = "[" <> testLabel <> "] " <> methodName
-
--- | Value (a, w) strictness tests for Monadic typeclass functions.
---
--- testStrictPairMonadic ::
---   forall writer.
---   (
---     -- MonadPlus (writer String []),
---     -- MonadPlus (writer String Maybe),
---     MonadIO (writer String IO)
---   ) =>
---   String ->
---   WriterBaseF writer ->
---   WriterMethods writer String IO ->
---   StrictPairMonadicExpectations ->
---   [TestTree]
--- testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMonadicExpectations {..} =
---   [
-  -- testProperty
-  --     (prop_name "Functor fmap")
-  --     ( \(Bot v :: (Bot ((), String))) ->
-  --         let expected = expect_bot_functor_fmap (isBottom v)
-  --          in test_pair_strictness_monad runWriterF expected $
-  --               (\w -> w <> w) <$> writerF (Identity v)
-  --     ),
-  --   testProperty
-  --     (prop_name "Monad >>=")
-  --     ( \(Bot v :: (Bot (Int, String)))
-  --        (Bot w :: (Bot ((), String))) -> do
-  --           let expected = expect_bot_monad_bind (isBottom v) (isBottom w)
-  --            in test_pair_strictness_monad runWriterF expected $
-  --                 writerF (Identity v) >>= const (writerF (Identity w))
-  --     ),
-  --   testProperty
-  --     (prop_name "Applicative <*>")
-  --     ( \(Bot v :: (Bot ((), String)))
-  --        (Bot u :: (Bot (F1 () (), String))) -> do
-  --           let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
-  --               u' :: (() -> (), String)
-  --               u' = coerce u
-  --            in test_pair_strictness_monad runWriterF expected $
-  --                 writerF (Identity u') <*> writerF (Identity v)
-  --     ),
-    -- testProperty
-    --   (prop_name "Applicative liftA2")
-    --   ( \(Bot v :: (Bot (Int, String)))
-    --      (Bot u :: (Bot (Int, String))) -> do
-    --         let expected = expect_bot_applicative_apply (isBottom v) (isBottom u)
-    --         test_pair_strictness_monad runWriterF expected $
-    --           liftA2 (+) (writerF (Identity v)) (writerF (Identity u))
-    --   ),
-    -- testProperty
-    --   -- NOTE: implementation of any fixed point functions must be lazy, so
-    --   -- mfix is lazy for all Writer types.
-    --   (prop_name "MonadFix mfix")
-    --   ( \(Bot v :: (Bot ([Int], String))) ->
-    --       let expected = expect_bot_mfix (isBottom v)
-    --        in test_pair_strictness_monad runWriterF expected $
-    --             mfix (\x -> writerF $ Identity $ first (x <>) v)
-    --   ),
-    -- testProperty
-    --   (prop_name "Alternative <|> - []")
-    --   ( \(v :: [Bot (Int, String)])
-    --      (w :: [Bot (Int, String)]) ->
-    --         let p' = coerce v :: [(Int, String)]
-    --             q' = coerce w :: [(Int, String)]
-    --             result = runWriterF $ writerF p' <|> writerF q'
-    --             expected = expect_bot_alternative_list (isBottom <$> p') (isBottom <$> q')
-    --          in any isBottom result === expected
-    --   ),
-    -- testProperty
-    --   (prop_name "Alternative <|> - Maybe")
-    --   ( \(v :: Maybe (Bot (Int, String)))
-    --      (w :: Maybe (Bot (Int, String))) ->
-    --         let p' = coerce v :: Maybe (Int, String)
-    --             q' = coerce w :: Maybe (Int, String)
-    --             result = runWriterF $ writerF p' `mplus` writerF q'
-    --          in any isBottom result === expect_bot_alternative_maybe (isBottom <$> p') (isBottom <$> q')
-    --   ),
-    -- testProperty
-    --   (prop_name "MonadPlus mplus - []")
-    --   ( \(v :: [Bot (Int, String)])
-    --      (w :: [Bot (Int, String)]) ->
-    --         let p' = coerce v :: [(Int, String)]
-    --             q' = coerce w :: [(Int, String)]
-    --             result = runWriterF $ writerF p' `mplus` writerF q'
-    --             expected = expect_bot_alternative_list (isBottom <$> p') (isBottom <$> q')
-    --          in any isBottom result === expected
-    --   ),
-
---     testProperty
---       (prop_name "Monad stack")
---       ( \(Bot v :: (Bot (Int, String)))
---          (Bot w :: (Bot (Int, String)))
---          ->
---             let expected = expect_bot_stack (isBottom v) (isBottom w)
---                 result :: TestMonadStack String (writer String IO) Int
---                 result = do
---                   q' <- lift $ lift $ writerF $ return w
---                   a <- lift ask
---                   b <- callCC $ \next -> do
---                     when (even a) $ next (10 :: Int)
---                     return 20
---                   p' <- lift $ lift $ writerF $ return v
---                   lift $ lift $ tell "hello"
---                   return $ q' + a + p' + b
---                 writer = censor (filter (/= 'l')) $ runTestMonadStack result show
---              in test_pair_strictness_IO (runWriterF @String) expected writer
---       )
---   ]
---   where
---     prop_name methodName = "[" <> testLabel <> "]" <> methodName
-
-type TestMonadStack r m a = (ContT r (ReaderT Int m) a)
-
-runTestMonadStack :: (Monad m) => TestMonadStack r m a -> (a -> r) -> m r
-runTestMonadStack m cont = runReaderT rd 0
-  where rd = runContT m $ \x -> reader $ const (cont x)
-
-unBotDeep :: Bot (a, Bot w) -> (a, w)
-unBotDeep = coerce
+bottomLabelFor :: String -> Bool -> String
+bottomLabelFor s x = s <> ": " <> (if x then bottomLabel else notBottomLabel)
 
 isStrictValue :: arg1 -> a -> Property
-isStrictValue x  = isStrict x . evaluate
+isStrictValue x  = isStrictIn x . evaluate
 
 isLazyValue :: a -> Property
 isLazyValue = isLazy . evaluate
 
--- Strictness in one argument:
--- The result (normalized to IO) should be bottom whenever arg1 is bottom.
-isStrict :: arg1 -> IO a -> Property
-isStrict x  = shouldBeBottom (isBottom x)
---   where p' = unBot p
-
--- Strictness in two arguments:
--- The result (normalized to IO) should be bottom whenever arg1 OR arg2 is bottom.
-isStrict2 :: arg1 -> arg2 -> IO a -> Property
-isStrict2 x y  = shouldBeBottom (isBottom x || isBottom y)
-
-isBottomDeep :: Bot (a, Bot w) -> Bool
-isBottomDeep (Bot p) = isBottom p || isBottom (snd p)
-
-isDeepStrict :: Bot (a, Bot w) -> IO b -> Property
-isDeepStrict p  = shouldBeBottom (isBottomDeep p)
-
-isDeepStrict2 :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO b -> Property
-isDeepStrict2 p q  = shouldBeBottom (isBottomDeep p || isBottomDeep q)
-
-isDeepStrict1 :: Bot (a, Bot w) -> arg1 -> IO b -> Property
-isDeepStrict1 p y  = shouldBeBottom (isBottomDeep p || isBottom y)
-
-isStrictAny :: [arg] -> IO a -> Property
-isStrictAny x = shouldBeBottom (any isBottom x)
-
+-- Never bottom
 isLazy :: IO a -> Property
 isLazy = shouldBeBottom False
 
-shouldBeBottom :: Bool -> IO a -> Property
-shouldBeBottom True result = label "Bottom" $ assertExceptionIO isBottomError result
+-- Strictness in one argument:
+-- The result (normalized to IO) should be bottom whenever arg1 is bottom.
+isStrictIn :: arg1 -> IO a -> Property
+isStrictIn x  =
+  let bottomX = isBottom x
+  in label (bottomLabelFor "arg" bottomX)
+    . shouldBeBottom bottomX
+
+-- Strictness in two arguments:
+-- The result (normalized to IO) should be bottom whenever arg1 OR arg2 is bottom.
+isBiStrictIn :: arg1 -> arg2 -> IO o -> Property
+isBiStrictIn x y  =
+    let bottomX = isBottom x
+        bottomY = isBottom y
+   in label (bottomLabelFor "arg1" bottomX <> ", " <> bottomLabelFor "arg2" bottomY)
+    . shouldBeBottom (bottomX || bottomY)
+
+shouldBeBottom :: Bool -> IO o -> Property
+shouldBeBottom expectBottom result = classify expectBottom bottomLabel $ 
+  if expectBottom 
+    then assertExceptionIO isBottomError result
+    else ioProperty $ do
+      v <- result
+      v `seq` return ()
   where
     -- Check error message only i.e. prefix, ignoring stacktrace.
     isBottomError :: ErrorCall -> Bool
     isBottomError e = "<bottom>" `isPrefixOf` displayException e
-shouldBeBottom False result = label "not Bottom" $ monadicIO $ run $ do
-  v <- result
-  v `seq` return ()
+
+-- unBot for CPS which is strict in both the spine (a,w) and log w.
+unBotDeeper :: Bot (a, Bot w) -> (a, w)
+unBotDeeper = coerce
+
+-- isBottom for CPS, which is strict in both the spine (a,w) and log w.
+isBottomDeeper :: Bot (a, Bot w) -> Bool
+isBottomDeeper (Bot p) = isBottom p || isBottom (snd p)
+
+-- isStrictIn analogue for deeper (CPS).
+isStrictDeeperIn :: Bot (a, Bot w) -> IO o -> Property
+isStrictDeeperIn p =
+  let bottomP = isBottomDeeper p
+  in label (bottomLabelFor "arg" bottomP)
+    . shouldBeBottom bottomP
+
+isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO o -> Property
+isBiStrictDeeperIn p q  =
+  let bottomP = isBottomDeeper p
+      bottomQ = isBottomDeeper q
+   in label (bottomLabelFor "arg1" bottomP <> ", " <> bottomLabelFor "arg2" bottomQ)
+     . shouldBeBottom (bottomP || bottomQ)
+
+isStrictDeeperInWith :: Bot (a, Bot w) -> arg1 -> IO o -> Property
+isStrictDeeperInWith p x  =
+  let bottomP = isBottomDeeper p
+      bottomX = isBottom x
+   in label (bottomLabelFor "arg1" bottomP <> ", " <> bottomLabelFor "arg2" bottomX)
+     . shouldBeBottom (bottomP || bottomX)

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module WriterStrictness (test) where
+
+import Control.Applicative
+import Control.Exception.Base (ErrorCall)
+import Control.Monad.Fix (mfix)
+import qualified Control.Monad.Trans.Writer.CPS as CPS
+import qualified Control.Monad.Trans.Writer.Lazy as Lazy
+import qualified Control.Monad.Trans.Writer.Strict as Strict
+import Data.Functor.Contravariant (Contravariant (contramap), Predicate (..))
+import GHC.IO (evaluate)
+import Test.ChasingBottoms (bottom)
+import Test.ChasingBottoms.IsBottom (isBottom)
+import Test.QuickCheck
+import Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Utils (Bot (..))
+
+test :: IO ()
+test = do
+  defaultMain $ testGroup "Writer" tests
+
+tests :: [TestTree]
+tests =
+  -- Basic methods
+  [ testFunction
+      "execWriter"
+      ( \(Bot v :: (Bot (String, ()))) ->
+          isBottom (Strict.execWriter $ Strict.writer v)
+            === isBottom v
+      )
+      ( \(Bot v :: (Bot (String, ()))) ->
+          isBottom (Lazy.execWriter $ Lazy.writer v)
+            === isBottom v
+      )
+      ( \(Bot v :: (Bot (String, ()))) ->
+          isBottom (CPS.execWriter $ CPS.writer v)
+            === isBottom v
+      ),
+    testFunction
+      "tell"
+      -- NOTE: tell involves no binding so result is the same as lazy.
+      (\(Bot v :: (Bot String)) -> test_strictness_strict False $ Strict.tell v)
+      (\(Bot v :: (Bot String)) -> test_strictness_lazy False $ Lazy.tell v)
+      (\(Bot v :: (Bot String)) -> test_strictness_cps (isBottom v) $ CPS.tell v),
+    testFunction
+      "tellIO"
+      -- NOTE: tell involves no binding so result is the same as lazy.
+      (\(Bot v :: (Bot String)) -> test_strictness_strict_IO False $ Strict.tell v)
+      (\(Bot v :: (Bot String)) -> test_strictness_lazy_IO False $ Lazy.tell v)
+      (\(Bot v :: (Bot String)) -> test_strictness_cps_IO (isBottom v) $ CPS.tell v),
+    testFunction
+      "listen"
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.listen $ Strict.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.listen $ Lazy.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.listen $ CPS.writer v),
+    testFunction
+      "listenIO"
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.listen $ Strict.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.listen $ Lazy.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.listen $ CPS.writer v),
+    testFunction
+      "listens"
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.listens id $ Strict.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.listens id $ Lazy.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.listens id $ CPS.writer v),
+    testFunction
+      "listensIO"
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.listens id $ Strict.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.listens id $ Lazy.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.listens id $ CPS.writer v),
+    testFunction
+      "pass"
+      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_strict (isBottom v) $ Strict.pass $ return v)
+      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_lazy False $ Lazy.pass $ return v)
+      (\(Bot v :: (Bot ((), String -> String))) -> test_strictness_cps (isBottom v) $ CPS.pass $ return v),
+    testFunction
+      "censor"
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_strict (isBottom v) $ Strict.censor id $ Strict.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy False $ Lazy.censor id $ Lazy.writer v)
+      (\(Bot v :: (Bot ((), String))) -> test_strictness_cps (isBottom v) $ CPS.censor id $ CPS.writer v)
+  ]
+    -- Type classes
+    ++ [ testFunction
+           "Functor"
+           (\(Bot v :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ (\w -> w <> w) <$> Strict.writer v)
+           (\(Bot v :: (Bot ((), String))) -> test_strictness_lazy_IO False $ (\w -> w <> w) <$> Lazy.writer v)
+           (\(Bot v :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ (\w -> w <> w) <$> CPS.writer v),
+         testFunction
+           "Applicative map"
+           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
+               let mapper =
+                     if isBottom u
+                       then
+                         Strict.writer bottom
+                       else
+                         Strict.writer (id, "")
+               test_strictness_strict_IO (isBottom v || isBottom u) $ mapper <*> Strict.writer v
+           )
+           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
+               let mapper =
+                     if isBottom u
+                       then
+                         Lazy.writer bottom
+                       else
+                         Lazy.writer (id, "")
+               test_strictness_lazy_IO False $ mapper <*> Lazy.writer v
+           )
+           ( \(Bot v :: (Bot ((), String))) (Bot u :: (Bot ())) -> do
+               let mapper =
+                     if isBottom u
+                       then
+                         CPS.writer bottom
+                       else
+                         CPS.writer (id, "")
+               test_strictness_cps_IO (isBottom v || isBottom u) $ mapper <*> CPS.writer v
+           ),
+         testFunction
+           "Monad bind"
+           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v || isBottom w) $ Strict.writer v >>= \_ -> Strict.writer w)
+           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_lazy_IO False $ Lazy.writer v >>= \_ -> Lazy.writer w)
+           (\(Bot v :: (Bot (Int, String))) (Bot w :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v || isBottom w) $ CPS.writer v >>= \_ -> CPS.writer w),
+         -- TODO
+         -- Foldable
+         -- Traversable
+         -- MonadFix
+         -- MonadFail
+         -- MonadPlus
+         -- MonadIO
+         -- MonadZip
+         -- MonadTrans
+         testFunction
+           ""
+           (True === True)
+           (True === True)
+           (True === True),
+         testFunction
+           "Alternative"
+           -- TODO: why does this only depend on v?
+           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_strict_IO (isBottom v) $ Strict.writer v <|> Strict.writer w)
+           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_lazy_IO (isBottom v) $ Lazy.writer v <|> Lazy.writer w)
+           (\(Bot v :: (Bot ((), String))) (Bot w :: (Bot ((), String))) -> test_strictness_cps_IO (isBottom v) $ CPS.writer v <|> CPS.writer w),
+         testGroup
+           "Contravariant"
+           [ testProperty
+               "strict"
+               ( \(Bot v :: (Bot (Int, String))) -> do
+                   let writer = Strict.WriterT $ Predicate (== (1, ""))
+                   isBottom (getPredicate (Strict.runWriterT $ contramap (+ 2) writer) v)
+                     === isBottom v
+               ),
+             testProperty
+               "lazy"
+               ( \(Bot v :: (Bot (Int, String))) -> do
+                   let writer = Lazy.WriterT $ Predicate (== (1, ""))
+                   -- TODO:
+                   isBottom (getPredicate (Lazy.runWriterT $ contramap (+ 2) writer) v)
+                     === isBottom v
+               )
+           ]
+       ]
+
+testFunction :: (Testable a) => String -> a -> a -> a -> TestTree
+testFunction name strict lazy cps =
+  testGroup
+    name
+    [ testProperty "strict" strict,
+      testProperty "lazy" lazy,
+      testProperty "cps" cps
+    ]
+
+test_strictness_monad :: forall k writer w (m :: k) a. (writer w m a -> (a, w)) -> Bool -> writer w m a -> Property
+test_strictness_monad runW True writer =
+  assertExceptionIO @ErrorCall (const True) (evaluate $ runW writer)
+test_strictness_monad runW False writer =
+  monadicIO $ run $ runW writer `seq` return ()
+
+test_strictness_IO :: (writer w IO a -> IO (a, w)) -> Bool -> writer w IO a -> Property
+test_strictness_IO runW True writer =
+  assertExceptionIO @ErrorCall (const True) (runW writer)
+test_strictness_IO runW False writer = monadicIO $ run $ do
+  v <- runW writer
+  v `seq` return ()
+
+test_strictness_lazy :: Bool -> Lazy.Writer w a -> Property
+test_strictness_lazy = test_strictness_monad Lazy.runWriter
+
+test_strictness_lazy_IO :: Bool -> Lazy.WriterT w IO a -> Property
+test_strictness_lazy_IO = test_strictness_IO Lazy.runWriterT
+
+test_strictness_strict_IO :: Bool -> Strict.WriterT w IO a -> Property
+test_strictness_strict_IO = test_strictness_IO Strict.runWriterT
+
+test_strictness_cps_IO :: (Monoid w) => Bool -> CPS.WriterT w IO a -> Property
+test_strictness_cps_IO = test_strictness_IO CPS.runWriterT
+
+test_strictness_strict :: Bool -> Strict.Writer w a -> Property
+test_strictness_strict = test_strictness_monad Strict.runWriter
+
+test_strictness_cps :: (Monoid w) => Bool -> CPS.Writer w a -> Property
+test_strictness_cps = test_strictness_monad CPS.runWriter

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,14 +1,13 @@
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module WriterStrictness (test) where
 
 import           Control.Applicative
+import           Control.Arrow (first)
 import           Control.Exception (ErrorCall (..), SomeException (..),
                                     evaluate)
 import           Control.Monad
@@ -44,29 +43,33 @@ import           Utils
 test :: IO ()
 test = defaultMain $ testGroup "Writer" strictPairTests
 
-data WriterBase writer = WriterBase {
-  writer    :: forall w m a. m (a, w) -> writer w m a,
-  runWriter :: forall w m a. writer w m a -> m (a, w)
-}
+data WriterBase writer
+  = WriterBase
+      { writer    :: forall w m a. m (a, w) -> writer w m a,
+        runWriter :: forall w m a. writer w m a -> m (a, w)
+      }
 
 -- CPS Writer requires Functor
-data WriterBaseF writer = WriterBaseF {
-  writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
-  runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
-}
+data WriterBaseF writer
+  = WriterBaseF
+      { writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
+        runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
+      }
 
-data WriterMethods writer w m = WriterMethods {
-  execWriterT :: forall a.    writer w m a -> m w,
-  mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
-  tell        ::              w -> writer w m (),
-  listen      :: forall  a.   writer w m a -> writer w m (a, w),
-  pass        :: forall  a.   writer w m (a, w -> w) -> writer w m a,
-  censor      :: forall  a.   (w -> w) -> writer w m a -> writer w m a
-}
+data WriterMethods writer w m
+  = WriterMethods
+      { execWriterT :: forall a. writer w m a -> m w,
+        mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
+        tell        :: w -> writer w m (),
+        listen      :: forall a. writer w m a -> writer w m (a, w),
+        pass        :: forall a. writer w m (a, w -> w) -> writer w m a,
+        censor      :: forall a. (w -> w) -> writer w m a -> writer w m a
+      }
 
-data WriterLifts writer = WriterLifts {
-  liftCatch   :: forall w m a e. Monoid w => Catch e m (a, w) -> Catch e (writer w m) a
-}
+data WriterLifts writer
+  = WriterLifts
+      { liftCatch :: forall w m a e. Monoid w => Catch e m (a, w) -> Catch e (writer w m) a
+      }
 
 lazyBaseF :: WriterBaseF Lazy.WriterT
 lazyBaseF = WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
@@ -75,19 +78,18 @@ lazyBase :: WriterBase Lazy.WriterT
 lazyBase = WriterBase {writer = Lazy.WriterT, runWriter = Lazy.runWriterT}
 
 lazyWriterMethods :: (Monad m) => WriterMethods Lazy.WriterT w m
-lazyWriterMethods = WriterMethods {
-  execWriterT = Lazy.execWriterT,
-  mapWriter = Lazy.mapWriterT,
-  tell = Lazy.tell,
-  listen = Lazy.listen,
-  pass = Lazy.pass,
-  censor = Lazy.censor
-}
+lazyWriterMethods =
+  WriterMethods
+    { execWriterT = Lazy.execWriterT,
+      mapWriter = Lazy.mapWriterT,
+      tell = Lazy.tell,
+      listen = Lazy.listen,
+      pass = Lazy.pass,
+      censor = Lazy.censor
+    }
 
 lazyWriterLifts :: WriterLifts Lazy.WriterT
-lazyWriterLifts = WriterLifts {
-  liftCatch = Lazy.liftCatch
-}
+lazyWriterLifts = WriterLifts { liftCatch = Lazy.liftCatch }
 
 strictBaseF :: WriterBaseF Strict.WriterT
 strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWriterT}
@@ -107,8 +109,9 @@ strictWriterMethods =
     }
 
 strictWriterLifts :: WriterLifts Strict.WriterT
-strictWriterLifts = WriterLifts {
-      liftCatch = Strict.liftCatch
+strictWriterLifts =
+  WriterLifts
+    { liftCatch = Strict.liftCatch
     }
 
 cpsBase :: WriterBaseF CPS.WriterT
@@ -116,8 +119,8 @@ cpsBase = WriterBaseF {writerF = CPS.writerT, runWriterF = CPS.runWriterT}
 
 cpsWriterMethods :: (Monad m, Monoid w) => WriterMethods CPS.WriterT w m
 cpsWriterMethods =
-  WriterMethods {
-      execWriterT = CPS.execWriterT,
+  WriterMethods
+    { execWriterT = CPS.execWriterT,
       mapWriter = CPS.mapWriterT,
       tell = CPS.tell,
       listen = CPS.listen,
@@ -126,12 +129,20 @@ cpsWriterMethods =
     }
 
 cpsWriterLifts :: WriterLifts CPS.WriterT
-cpsWriterLifts = WriterLifts {
-      liftCatch = CPS.liftCatch
+cpsWriterLifts =
+  WriterLifts
+    { liftCatch = CPS.liftCatch
     }
 
--- Strictness tests for the *pair* (a, w)
--- In particular this test is for
+-- | Strictness tests for the value (a, w) of Writers
+--
+-- Test whether the pair (a, w) is handled lazily/strictly
+-- in Writer functions as expected.
+-- In particular, whether pairs patterns are handled correctly
+-- in the respective Writers.
+--
+-- Please note that tests DO NOT test strictness in the log w
+-- of the CPS writer.
 --
 strictPairTests :: [TestTree]
 strictPairTests =
@@ -140,7 +151,7 @@ strictPairTests =
     lazyBase
     StrictPairTypeClassExpectations
       { expect_bot_foldMap = const False,
-        expect_bot_traverse = id,           -- WARN: not lazy pattern
+        expect_bot_traverse = id,           -- NOTE: does not use lazy pattern match
         expect_bot_mzipWith = const2 False,
         expect_bot_contramap = const False
       }
@@ -148,7 +159,7 @@ strictPairTests =
       "Strict"
       strictBase
       StrictPairTypeClassExpectations
-        { expect_bot_foldMap = const False, -- WARN: lazy due to use of fst
+        { expect_bot_foldMap = const False, -- NOTE: lazy due to use of fst
           expect_bot_traverse = id,
           expect_bot_mzipWith = (||),
           expect_bot_contramap = id
@@ -163,8 +174,8 @@ strictPairTests =
           expect_bot_applicative_apply = const2 False,
           expect_bot_alternative_list = \x y -> or $ x <> y,
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = id,             -- WARN: same as strict
-          expect_bot_stack = const2  False
+          expect_bot_mfix = const False,
+          expect_bot_stack = const2 False
         }
     ++ testStrictPairMonadic
       "Strict"
@@ -176,7 +187,7 @@ strictPairTests =
           expect_bot_applicative_apply = (||),
           expect_bot_alternative_list = \x y -> or $ x <> y,
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
-          expect_bot_mfix = id,
+          expect_bot_mfix = const False,       -- NOTE: fix must be lazy
           expect_bot_stack = (||)
         }
     ++ testStrictPairMonadic
@@ -234,49 +245,6 @@ strictPairTests =
           expect_bot_censor = id,
           expect_bot_combination = \t u v w -> or [t, u, v, w]
         }
-    -- Maybe
-    ++ testStrictPairMethods
-      "Lazy + Maybe"
-      fromJust
-      lazyBaseF
-      lazyWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,             -- NOTE: same as strict since it reduces to the log w
-          expect_bot_mapWriter_strict = id,       -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = const False,
-          expect_bot_pass = const False,
-          expect_bot_censor = const False,
-          expect_bot_combination = const2 . const2 False
-        }
-    ++ testStrictPairMethods
-      "Strict + Maybe"
-      fromJust
-      strictBaseF
-      strictWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,          -- NOTE: mapWriter depends only on the strictness of the map function provided by caller
-          expect_bot_mapWriter_lazy = const False,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
-    ++ testStrictPairMethods
-      "CPS + Maybe"
-      fromJust
-      cpsBase
-      cpsWriterMethods
-      StrictPairMethodsExpectations
-        { expect_bot_execWriter = id,
-          expect_bot_mapWriter_strict = id,
-          expect_bot_mapWriter_lazy = id,
-          expect_bot_listen = id,
-          expect_bot_pass = id,
-          expect_bot_censor = id,
-          expect_bot_combination = \t u v w -> or [t, u, v, w]
-        }
     ++ testStrictPairMethods
       "Lazy + IO"
       unsafePerformIO
@@ -323,38 +291,39 @@ strictPairTests =
       "Lazy"
       lazyBaseF
       lazyWriterLifts
-      StrictPairLiftsExpectations {
-        expect_bot_liftCatch = id             -- WARN: same as strict since the value is just passed through.
-      }
+      StrictPairLiftsExpectations
+        { expect_bot_liftCatch = id  -- NOTE: same as strict since the value is just passed through.
+        }
     ++ testStrictPairLifts
       "Strict"
       strictBaseF
       strictWriterLifts
-      StrictPairLiftsExpectations {
-        expect_bot_liftCatch = id
-      }
+      StrictPairLiftsExpectations
+        { expect_bot_liftCatch = id
+        }
     ++ testStrictPairLifts
       "CPS"
       cpsBase
       cpsWriterLifts
-      StrictPairLiftsExpectations {
-        expect_bot_liftCatch = id
-      }
+      StrictPairLiftsExpectations
+        { expect_bot_liftCatch = id
+        }
 
 -- Expected values of tests.
-data StrictPairMethodsExpectations = StrictPairMethodsExpectations {
-    expect_bot_execWriter       :: Bool -> Bool,
-    expect_bot_mapWriter_strict :: Bool -> Bool,
-    expect_bot_mapWriter_lazy   :: Bool -> Bool,
-    expect_bot_listen           :: Bool -> Bool,
-    expect_bot_pass             :: Bool -> Bool,
-    expect_bot_censor           :: Bool -> Bool,
-    expect_bot_combination      :: Bool -> Bool -> Bool -> Bool -> Bool
-  }
+data StrictPairMethodsExpectations
+  = StrictPairMethodsExpectations
+      { expect_bot_execWriter       :: Bool -> Bool,
+        expect_bot_mapWriter_strict :: Bool -> Bool,
+        expect_bot_mapWriter_lazy   :: Bool -> Bool,
+        expect_bot_listen           :: Bool -> Bool,
+        expect_bot_pass             :: Bool -> Bool,
+        expect_bot_censor           :: Bool -> Bool,
+        expect_bot_combination      :: Bool -> Bool -> Bool -> Bool -> Bool
+      }
 
--- |
+-- | Value (a, w) strictness tests for the core Writer methods.
 --
--- Not tested:
+-- Functions that do not involve handling pairs are not tested:
 -- * tell
 testStrictPairMethods ::
   forall writer m.
@@ -366,13 +335,12 @@ testStrictPairMethods ::
   StrictPairMethodsExpectations ->
   [TestTree]
 testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
-  [
-    testProperty
-        (prop_name "execWriter")
-        ( \(Bot v :: (Bot ((), String))) ->
+  [ testProperty
+      (prop_name "execWriter")
+      ( \(Bot v :: (Bot ((), String))) ->
           let result = runMonad $ execWriterT $ writerF $ return @m v
-             in isBottom result === expect_bot_execWriter (isBottom v)
-        ),
+           in isBottom result === expect_bot_execWriter (isBottom v)
+      ),
 
     -- NOTE: strictness depends only on the strictness of the provided map
     testProperty
@@ -411,7 +379,7 @@ testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} Str
       (prop_name "censor")
       ( \(Bot v :: (Bot ((), String))) ->
           test_pair_strictness_monad runW (expect_bot_censor (isBottom v)) $
-            censor copyMonoid $
+            censor (\w -> w <> w) $
               writerF $
                 returnM v
       ),
@@ -443,15 +411,16 @@ testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} Str
     returnM :: (a, w) -> m (a, w)
     returnM = return @m
 
-data StrictPairLiftsExpectations = StrictPairLiftsExpectations {
-    expect_bot_liftCatch  :: Bool -> Bool
-  }
+data StrictPairLiftsExpectations
+  = StrictPairLiftsExpectations
+      { expect_bot_liftCatch :: Bool -> Bool
+      }
 
--- |
+-- | Value (a, w) strictness tests for lifts.
+--
 -- In general, lifts do not involve pairs (a, w), since the log w is
 -- not visible to other monads in the stack.
 -- Hence, tests are omitted for:
---
 -- * lift
 -- * liftIO
 -- * liftCallCC
@@ -490,13 +459,16 @@ testStrictPairLifts testLabel WriterBaseF {..} WriterLifts {..} StrictPairLiftsE
     e = error "this should never happen"
     prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
-data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations {
-    expect_bot_foldMap   :: Bool -> Bool,
-    expect_bot_traverse  :: Bool -> Bool,
-    expect_bot_mzipWith  :: Bool -> Bool -> Bool,
-    expect_bot_contramap :: Bool -> Bool
-  }
+data StrictPairTypeClassExpectations
+  = StrictPairTypeClassExpectations
+      { expect_bot_foldMap   :: Bool -> Bool,
+        expect_bot_traverse  :: Bool -> Bool,
+        expect_bot_mzipWith  :: Bool -> Bool -> Bool,
+        expect_bot_contramap :: Bool -> Bool
+      }
 
+-- | Value (a, w) strictness tests for type class functions other than Monads.
+--
 testStrictPairTypeClass ::
   forall writer.
   ( Traversable (writer String []),
@@ -539,27 +511,29 @@ testStrictPairTypeClass testLabel WriterBase {..} StrictPairTypeClassExpectation
   where
     prop_name methodName = "[" <> testLabel <> "] " <> methodName
 
-data StrictPairMonadicExpectations = StrictPairMonadicExpectations {
-    expect_bot_functor_fmap      :: Bool -> Bool,
-    expect_bot_monad_bind        :: Bool -> Bool -> Bool,
-    expect_bot_applicative_apply :: Bool -> Bool -> Bool,
-    expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
-    expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
-    expect_bot_mfix              :: Bool -> Bool,
-    expect_bot_stack             :: Bool -> Bool -> Bool
-  }
+data StrictPairMonadicExpectations
+  = StrictPairMonadicExpectations
+      { expect_bot_functor_fmap      :: Bool -> Bool,
+        expect_bot_monad_bind        :: Bool -> Bool -> Bool,
+        expect_bot_applicative_apply :: Bool -> Bool -> Bool,
+        expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
+        expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
+        expect_bot_mfix              :: Bool -> Bool,
+        expect_bot_stack             :: Bool -> Bool -> Bool
+      }
 
+-- | Value (a, w) strictness tests for Monadic typeclass functions.
+--
 testStrictPairMonadic ::
   forall writer.
-  ( MonadFix (writer String Maybe),
+  ( MonadFix (writer String Identity),
     MonadPlus (writer String []),
     MonadPlus (writer String Maybe),
-    MonadTrans (writer String),
     MonadIO (writer String IO)
   ) =>
   String ->
   WriterBaseF writer ->
-    WriterMethods writer String IO->
+  WriterMethods writer String IO ->
   StrictPairMonadicExpectations ->
   [TestTree]
 testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMonadicExpectations {..} =
@@ -597,11 +571,13 @@ testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMo
               liftA2 (+) (writerF (Identity v)) (writerF (Identity u))
       ),
     testProperty
+      -- NOTE: implementation of any fixed point functions must be lazy, so
+      -- mfix is lazy for all Writer types.
       (prop_name "MonadFix mfix")
-      ( \(Bot v :: (Bot (Int, String))) ->
+      ( \(Bot v :: (Bot ([Int], String))) ->
           let expected = expect_bot_mfix (isBottom v)
-           in test_pair_strictness_monad (fromJust . runWriterF) expected $
-                mfix (const (writerF $ Just v))
+           in test_pair_strictness_monad runWriterF expected $
+                mfix (\x -> writerF $ Identity $ first (x <>) v)
       ),
     testProperty
       (prop_name "Alternative <|> - []")
@@ -635,17 +611,16 @@ testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMo
 
     testProperty
       (prop_name "Monad stack")
-      ( \
-         (Bot v :: (Bot (Int, String)))
+      ( \(Bot v :: (Bot (Int, String)))
          (Bot w :: (Bot (Int, String)))
-                ->
+         ->
             let expected = expect_bot_stack (isBottom v) (isBottom w)
                 result :: TestMonadStack String (writer String IO) Int
                 result = do
                   w' <- lift $ lift $ writerF $ return w
                   a <- lift ask
                   b <- callCC $ \next -> do
-                    when (even a) $ next (10 ::Int)
+                    when (even a) $ next (10 :: Int)
                     return 20
                   v' <- lift $ lift $ writerF $ return v
                   lift $ lift $ tell "hello"
@@ -657,17 +632,14 @@ testStrictPairMonadic testLabel WriterBaseF {..} WriterMethods {..} StrictPairMo
   where
     prop_name methodName = "[" <> testLabel <> "]" <> methodName
 
-copyMonoid :: (Monoid w) => w -> w
-copyMonoid w = w <> w
-
-const2 :: a -> b -> c -> a
-const2 = const . const
-
 type TestMonadStack r m a = (ContT r (ReaderT Int m) a)
 
 runTestMonadStack :: (Monad m) => TestMonadStack r m a -> (a -> r) -> m r
 runTestMonadStack m cont = runReaderT rd 0
   where rd = runContT m $ \x -> reader $ const (cont x)
+
+const2 :: a -> b -> c -> a
+const2 = const . const
 
 test_pair_strictness_monad :: forall k writer w (m :: k) a b. (writer w m a -> b) -> Bool -> writer w m a -> Property
 test_pair_strictness_monad runWriter expected writer = test_pair_strictness_IOBase expected $ evaluate (runWriter writer)
@@ -676,6 +648,7 @@ test_pair_strictness_IO :: (writer w IO a -> IO b) -> Bool -> writer w IO a -> P
 test_pair_strictness_IO runW expected = test_pair_strictness_IOBase expected . runW
 
 test_pair_strictness_IOBase :: Bool -> IO a -> Property
-test_pair_strictness_IOBase True wr =
-  assertExceptionIO @ErrorCall (const True)  wr
-test_pair_strictness_IOBase False wr = monadicIO $ run $ (`seq` ()) <$> wr
+test_pair_strictness_IOBase True v = assertExceptionIO @ErrorCall (const True) v
+test_pair_strictness_IOBase False v = monadicIO $ run $ do
+  v' <- v
+  v' `seq` return ()

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -9,97 +10,100 @@
 
 module WriterStrictness (test) where
 
-import Control.Applicative
-import Control.Exception (ErrorCall, evaluate)
-import Control.Monad
-import Control.Monad.Fix
-import Control.Monad.IO.Class
-import Control.Monad.Signatures (CallCC, Catch)
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Reader (ReaderT (..), ask)
+import           Control.Applicative
+import           Control.Exception (ErrorCall (..), Exception,
+                                    SomeException (..), evaluate, throw)
+import           Control.Monad
+import           Control.Monad.Fix
+import           Control.Monad.IO.Class
+import           Control.Monad.Signatures (CallCC, Catch)
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except (ExceptT (..), throwE)
+import           Control.Monad.Trans.Reader (ReaderT (..), ask)
 import qualified Control.Monad.Trans.Writer.CPS as CPS
 import qualified Control.Monad.Trans.Writer.Lazy as Lazy
 import qualified Control.Monad.Trans.Writer.Strict as Strict
-import Control.Monad.Zip
-import Data.Coerce
-import Data.Functor.Contravariant
-import Data.Functor.Identity
-import Data.Maybe
-import Data.Monoid
-import Test.ChasingBottoms.IsBottom (isBottom)
-import Test.QuickCheck
-import Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
-import Test.Tasty
-import Test.Tasty.QuickCheck
-import Utils
+import           Control.Monad.Zip
+
+import           Data.Coerce
+import           Data.Functor.Contravariant
+import           Data.Functor.Identity
+import           Data.Maybe
+import           Data.Monoid
+
+import           Test.ChasingBottoms.IsBottom (isBottom)
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Utils
 
 test :: IO ()
 test = defaultMain $ testGroup "Writer" strictPairTests
 
-data WriterBase writer = WriterBase
-  { writer :: forall w m a. (Monoid w) => m (a, w) -> writer w m a,
-    runWriter :: forall w m a. (Monoid w) => writer w m a -> m (a, w)
+data WriterBase writer = WriterBase {
+    writer    :: forall w m a. m (a, w) -> writer w m a,
+    runWriter :: forall w m a. writer w m a -> m (a, w)
   }
 
 -- CPS Writer requires Functor
-data WriterBaseF writer = WriterBaseF
-  { writerF :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
+data WriterBaseF writer = WriterBaseF {
+    writerF    :: forall w m a. (Functor m, Monoid w) => m (a, w) -> writer w m a,
     runWriterF :: forall w m a. (Functor m, Monoid w) => writer w m a -> m (a, w)
   }
 
-data WriterMethods writer = WriterMethods
-  { execWriterT :: forall w m a. (Monad m, Monoid w) => writer w m a -> m w,
-    mapWriter :: forall w m a w' n b. (Monad n, Monoid w, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
-    tell :: forall w m. (Monad m, Monoid w) => w -> writer w m (),
-    listen :: forall w m a. (Monad m, Monoid w) => writer w m a -> writer w m (a, w),
-    pass :: forall w m a. (Monad m, Monoid w) => writer w m (a, w -> w) -> writer w m a,
-    censor :: forall w m a. (Monad m, Monoid w) => (w -> w) -> writer w m a -> writer w m a,
-    liftCallCC :: forall w m a b. (Monad m, Monoid w) => CallCC m (a, w) (b, w) -> CallCC (writer w m) a b,
-    liftCatch :: forall w m a e. Catch e m (a, w) -> Catch e (writer w m) a
+data WriterMethods writer w m = WriterMethods {
+    execWriterT :: forall a.   writer w m a -> m w,
+    mapWriter   :: forall a w' n b. (Monad n, Monoid w') => (m (a, w) -> n (b, w')) -> writer w m a -> writer w' n b,
+    tell        ::              w -> writer w m (),
+    listen      :: forall  a.   writer w m a -> writer w m (a, w),
+    pass        :: forall  a.   writer w m (a, w -> w) -> writer w m a,
+    censor      :: forall  a.   (w -> w) -> writer w m a -> writer w m a,
+    liftCallCC  :: forall  a b. CallCC m (a, w) (b, w) -> CallCC (writer w m) a b,
+    liftCatch   :: forall  a e. Catch e m (a, w) -> Catch e (writer w m) a
   }
 
-data StrictPairMethodsExpectations = StrictPairMethodsExpectations
-  { expect_bot_execWriter :: Bool -> Bool,
-    expect_bot_mapWriter :: Bool -> Bool,
-    expect_bot_tell :: Bool -> Bool,
-    expect_bot_listen :: Bool -> Bool,
-    expect_bot_pass :: Bool -> Bool,
-    expect_bot_censor :: Bool -> Bool,
-    expect_bot_liftCallCC :: Bool -> Bool,
-    expect_bot_liftCatch :: Bool -> Bool,
+data StrictPairMethodsExpectations = StrictPairMethodsExpectations {
+    expect_bot_execWriter  :: Bool -> Bool,
+    expect_bot_mapWriter   :: Bool -> Bool,
+    expect_bot_tell        :: Bool -> Bool,
+    expect_bot_listen      :: Bool -> Bool,
+    expect_bot_pass        :: Bool -> Bool,
+    expect_bot_censor      :: Bool -> Bool,
+    expect_bot_liftCallCC  :: Bool -> Bool,
+    expect_bot_liftCatch   :: Bool -> Bool,
     expect_bot_combination :: Bool -> Bool -> Bool -> Bool -> Bool
   }
 
-data StrictPairMonadicExpectations = StrictPairMonadicExpectations
-  { expect_bot_functor_fmap :: Bool -> Bool,
-    expect_bot_monad_bind :: Bool -> Bool -> Bool,
+data StrictPairMonadicExpectations = StrictPairMonadicExpectations {
+    expect_bot_functor_fmap      :: Bool -> Bool,
+    expect_bot_monad_bind        :: Bool -> Bool -> Bool,
     expect_bot_applicative_apply :: Bool -> Bool -> Bool,
-    expect_bot_alternative_list :: [Bool] -> [Bool] -> Bool,
+    expect_bot_alternative_list  :: [Bool] -> [Bool] -> Bool,
     expect_bot_alternative_maybe :: Maybe Bool -> Maybe Bool -> Bool,
-    expect_bot_mfix :: Bool -> Bool,
-    expect_bot_lift :: Bool -> Bool,
-    expect_bot_nested :: Bool -> Bool -> Bool
+    expect_bot_mfix              :: Bool -> Bool,
+    expect_bot_lift              :: Bool -> Bool,
+    expect_bot_nested            :: Bool -> Bool -> Bool 
   }
 
-data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations
-  { expect_bot_foldMap :: Bool -> Bool,
-    expect_bot_traverse :: Bool -> Bool,
-    expect_bot_mzipWith :: Bool -> Bool -> Bool,
+data StrictPairTypeClassExpectations = StrictPairTypeClassExpectations {
+    expect_bot_foldMap   :: Bool -> Bool,
+    expect_bot_traverse  :: Bool -> Bool,
+    expect_bot_mzipWith  :: Bool -> Bool -> Bool,
     expect_bot_contramap :: Bool -> Bool
   }
 
 lazyBaseF :: WriterBaseF Lazy.WriterT
-lazyBaseF =
-  WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
+lazyBaseF = WriterBaseF {writerF = Lazy.WriterT, runWriterF = Lazy.runWriterT}
 
 lazyBase :: WriterBase Lazy.WriterT
 lazyBase = WriterBase {writer = Lazy.WriterT, runWriter = Lazy.runWriterT}
 
-lazyWriterMethods :: WriterMethods Lazy.WriterT
+lazyWriterMethods :: (Monad m, Monoid w) => WriterMethods Lazy.WriterT w m
 lazyWriterMethods =
-  WriterMethods
-    { execWriterT = Lazy.execWriterT,
+  WriterMethods {
+      execWriterT = Lazy.execWriterT,
       mapWriter = Lazy.mapWriterT,
       tell = Lazy.tell,
       listen = Lazy.listen,
@@ -115,7 +119,7 @@ strictBaseF = WriterBaseF {writerF = Strict.WriterT, runWriterF = Strict.runWrit
 strictBase :: WriterBase Strict.WriterT
 strictBase = WriterBase {writer = Strict.WriterT, runWriter = Strict.runWriterT}
 
-strictWriterMethods :: WriterMethods Strict.WriterT
+strictWriterMethods :: (Monad m, Monoid w) => WriterMethods Strict.WriterT w m
 strictWriterMethods =
   WriterMethods
     { execWriterT = Strict.execWriterT,
@@ -131,7 +135,7 @@ strictWriterMethods =
 cpsBase :: WriterBaseF CPS.WriterT
 cpsBase = WriterBaseF {writerF = CPS.writerT, runWriterF = CPS.runWriterT}
 
-cpsWriterMethods :: WriterMethods CPS.WriterT
+cpsWriterMethods :: (Monad m, Monoid w) => WriterMethods CPS.WriterT w m
 cpsWriterMethods =
   WriterMethods
     { execWriterT = CPS.execWriterT,
@@ -177,7 +181,7 @@ strictPairTests =
           expect_bot_alternative_maybe = \x y -> fromMaybe False $ x <|> y,
           expect_bot_mfix = id, -- NOTE: same as strict
           expect_bot_lift = const False,
-          expect_bot_nested = const2 False
+          expect_bot_nested = const2  False
         }
     ++ testStrictPairMonadic
       "Strict"
@@ -293,7 +297,7 @@ testStrictPairMethods ::
   String ->
   (forall a. m a -> a) ->
   WriterBaseF writer ->
-  WriterMethods writer ->
+  WriterMethods writer String m ->
   StrictPairMethodsExpectations ->
   [TestTree]
 testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} StrictPairMethodsExpectations {..} =
@@ -327,9 +331,7 @@ testStrictPairMethods testLabel runMonad WriterBaseF {..} WriterMethods {..} Str
       (prop_name "listen")
       ( \(Bot v :: (Bot ((), String))) ->
           test_pair_strictness_monad runW (expect_bot_listen (isBottom v)) $
-            listen $
-              writerF $
-                returnM v
+            listen $ writerF $ returnM v
       ),
     testProperty
       (prop_name "pass")
@@ -528,30 +530,54 @@ testStrictPairMonadic testLabel WriterBaseF {..} StrictPairMonadicExpectations {
       ),
     testProperty
       (prop_name "Monad nested")
-      ( \(Bot v :: (Bot (Int, String)))
-         (Bot w :: (Bot (Int, String))) ->
+      ( \
+         (Bot u :: (Bot (Int, String)))
+         (Bot v :: (Bot (Int, String)))
+         (Bot w :: (Bot (Int, String)))
+                ->
             let expected = expect_bot_nested (isBottom v) (isBottom w)
-                result :: ContT Int (ReaderT Int (writer String IO)) Int
-                result = do
+                result :: TestMonad TestException (writer String IO) Int
+                result = TestMonad $ do
                   s <- lift $ lift $ writerF $ return v
+                  a <- lift $ lift  $ writerF $ return w
                   t <- lift ask
-                  u <-
-                    callCC
-                      ( \f -> do
-                          x <- f $ s + t
-                          f x
-                      )
-                  a <- lift $ lift $ writerF $ return w
-                  return $ u * a
-                q =
-                  let reader = runContT result return
-                   in runWriterF $ runReaderT reader 1
-             in test_pair_strictness_IO (runWriterF @String) expected $
-                  liftIO q
+                  when (isBottom u) $ throwE TestException
+                  return $ s + t * a
+             in test_pair_strictness_IO (runWriterF @String) (expected || isBottom u) $
+               runTestMonad result 
       )
   ]
   where
     prop_name methodName = "[" <> testLabel <> "]" <> methodName
+
+newtype TestMonad e m a = TestMonad (ExceptT e (ReaderT Int m) a)
+  deriving newtype (Functor, Applicative, Monad)
+
+data TestException = TestException
+  deriving (Show, Eq)
+
+instance Exception TestException where
+
+instance MonadTrans (TestMonad e) where
+  lift m = TestMonad $ lift $ lift m
+
+-- runTestMonad :: (MonadIO m, Exception e) => TestMonad e m a -> m a
+runTestMonad :: (MonadIO m) => TestMonad e m a -> m a
+runTestMonad (TestMonad m)  = do
+    result <- x
+    case result of
+      Right v -> return v
+      -- Left _  -> liftIO $ evaluate $ error "OOP"
+      -- Left _  -> liftIO $ evaluate $ error "OOP"
+      Left _  -> liftIO $ evaluate bottom
+      -- Left _  -> return y
+  where x = (runReaderT $ runExceptT m) 0
+
+-- testMonad :: (Monad m) => m a -> TestMonad m a
+-- testMonad = TestMonad . lift . lift
+
+-- runTestMonad :: (Monad m) => TestMonad m Int -> (Int -> m Int) -> Int -> m Int
+-- runTestMonad (TestMonad m) f = runReaderT (runContT m (lift . f))
 
 test_pair_strictness_monad :: forall k writer w (m :: k) a b. (writer w m a -> b) -> Bool -> writer w m a -> Property
 test_pair_strictness_monad runW True wr =

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module WriterStrictness (test) where
 
@@ -30,7 +25,7 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 test :: IO ()
-test = defaultMain $ testGroup "Writer" strictSpineTest
+test = defaultMain $ testGroup "Writer" strictnessTest
 
 -- | Monoid choice
 --
@@ -60,12 +55,12 @@ type SumInt = Sum Int
 --
 --  Writer.CPS      strict in spine (a,w) and log w
 --
-strictSpineTest :: [TestTree]
-strictSpineTest = [
-  testGroup "writer" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p,
-      testProperty "Strict" $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p,
-      testProperty "CPS"    $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p)
+strictnessTest :: [TestTree]
+strictnessTest = [
+  testGroup "Strictness" [
+      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p),
+      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.writer (unBotDeeper p),
+      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p)
   ],
 
   -- Lazy, Strict Writer    output of map is used directly without any intervention by the Writer itself
@@ -73,30 +68,30 @@ strictSpineTest = [
   --
   -- CPS Writer             output of map is evaluated in the log w
   testGroup "mapWriter" [
-      testProperty "Lazy" $ \m (f  :: F1Bot ((), SumInt) ((), SumInt)) ->
+      testProperty "Lazy"   $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             result = f' ((), mempty)
         in isStrictIn result $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT (f'<$>) $ pure (),
-      testProperty "Strict" $ \m (f  :: F1Bot ((), SumInt) ((), SumInt)) ->
+      testProperty "Strict" $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = unF1Bot f
             result = f' ((), mempty)
         in isStrictIn result $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT (f'<$>) $ pure (),
-      testProperty "CPS" $ \m (f  :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+      testProperty "CPS"    $ \m (f  :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = coerce f :: ((), SumInt) -> ((), SumInt)
             result = f' ((), mempty)
         in isBiStrictIn result (snd result) $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT (f'<$>) $ pure ()
   ],
 
   testGroup "listen" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Float, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (Bot (p :: (Float, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (p :: Bot (Float, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeeper p)
+      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.WriterT $ return (unBotDeeper p),
+      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.WriterT $ return (unBotDeeper p),
+      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer (unBotDeeper p)
   ],
 
   testGroup "listens" [
-      testProperty "Lazy"   $ \m (Bot (p :: (Float, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (Bot (p :: (Float, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (p :: Bot (Float, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeeper p)
+      testProperty "Lazy"   $ \m (p :: Bot ((), Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listens id $ Lazy.WriterT $ return (unBotDeeper p),
+      testProperty "Strict" $ \m (p :: Bot ((), Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.listens id $ Strict.WriterT $ return (unBotDeeper p),
+      testProperty "CPS"    $ \m (p :: Bot ((), Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ CPS.listens id $ CPS.writer (unBotDeeper p)
   ],
 
   testGroup "tell" [
@@ -113,62 +108,66 @@ strictSpineTest = [
   -- Lazy, Strict Writers are only concerned with 1.
   -- CPS Writer is strict in all.
   testGroup "censor" [
-      testProperty "Lazy"   $ \m (Bot (w :: SumInt)) (Bot (p :: ((), SumInt))) ->
-        isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor (<> w) $ Lazy.WriterT $ return p,
-      testProperty "Strict" $ \m (Bot (w :: SumInt)) (Bot (p :: ((), SumInt))) ->
-        isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor (<> w) $ Strict.WriterT $ return p,
-      testProperty "CPS"    $ \m (Bot (w :: SumInt)) (p :: Bot ((), Bot SumInt)) ->
-        isStrictDeeperInWith p w $ withBaseMonad m $ CPS.runWriterT $ CPS.censor (<> w) $ CPS.writer (unBotDeeper p)
+      testProperty "Lazy"   $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+        let f' = coerce f :: SumInt -> SumInt
+        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor f' $ Lazy.WriterT $ return p,
+      testProperty "Strict" $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+        let f' = coerce f :: SumInt -> SumInt
+        in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.censor f' $ Strict.WriterT $ return p,
+      testProperty "CPS"    $ \m (f :: F1Bot SumInt SumInt) (Bot (p :: ((), SumInt))) ->
+        let f' = coerce f :: SumInt -> SumInt
+            result = f' mempty
+        in isBiStrictIn p result $ withBaseMonad m $ CPS.runWriterT $ CPS.censor f' $ CPS.writer p
   ],
 
   -- See note on censor above.
   testGroup "pass" [
-      testProperty "Lazy"   $ \m (p :: Bot (((), F1 SumInt SumInt), SumInt)) ->
+      testProperty "Lazy"   $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
         in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ Lazy.WriterT $ return p',
-      testProperty "Strict"   $ \m (p :: Bot (((), F1 SumInt SumInt), SumInt)) ->
+      testProperty "Strict" $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
         in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ return p',
-      testProperty "CPS"    $ \m (p :: Bot (((), F1Bot SumInt SumInt), Bot SumInt)) ->
+      testProperty "CPS"    $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-            v  = (snd $ fst p') mempty
-        in isStrictDeeperInWith p v $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer p'
+            result  = (snd $ fst p') mempty
+        in isBiStrictIn p result $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer p'
   ],
 
   -- == Functor/Applicative/Monad ==
   testGroup "Functor: fmap" [
-      testProperty "Lazy"    $ \m (Bot (p :: (Int, SumInt))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return p),
-      testProperty "Strict"  $ \m (Bot (p :: (Int, SumInt))) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return p),
+      testProperty "Lazy"    $ \m (p :: Bot (Int, Bot SumInt)) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ (+1) <$> Lazy.WriterT (return (unBotDeeper p)),
+      testProperty "Strict"  $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ (+1) <$> Strict.WriterT (return (unBotDeeper p)),
       testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) -> isStrictDeeperIn p $ withBaseMonad m $ CPS.runWriterT $ (+1) <$> CPS.writer (unBotDeeper p)
     ],
 
   testGroup "Applicative: <*>" [
-      testProperty "Lazy"    $ \m (Bot (wf :: (F1 () (), SumInt))) (Bot (p :: ((), SumInt))) ->
+      testProperty "Lazy"    $ \m(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer p ,
-      testProperty "Strict"  $ \m(Bot (wf :: (F1 () (), SumInt))) (Bot (p :: ((), SumInt))) ->
+         in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer (unBotDeeper p),
+      testProperty "Strict"  $ \m(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
-         in isBiStrictIn p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer p,
+         in isBiStrictIn p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer (unBotDeeper p),
       testProperty "CPS"     $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
          in isBiStrictDeeperIn p wf $ withBaseMonad m $ CPS.runWriterT $ CPS.writer f' <*> CPS.writer (unBotDeeper p)
     ],
 
   testGroup "Applicative: liftA2" [
-      testProperty "Lazy"    $ \m (Bot (p :: (Int, SumInt))) (Bot (q :: (Int, SumInt))) ->
-          isLazy $ withBaseMonad m $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer p) (Lazy.writer q),
-      testProperty "Strict"  $ \m (Bot (p :: (Int, SumInt))) (Bot (q :: (Int, SumInt))) ->
-          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer p) (Strict.writer q),
+      testProperty "Lazy"    $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isLazy $ withBaseMonad m $ Lazy.runWriterT $ liftA2 (+) (Lazy.writer $ unBotDeeper p) (Lazy.writer $ unBotDeeper q),
+      testProperty "Strict"  $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ liftA2 (+) (Strict.writer $ unBotDeeper p) (Strict.writer $ unBotDeeper q),
       testProperty "CPS"     $ \m (p :: Bot (Int, Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
           isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ liftA2 (+) (CPS.writer $ unBotDeeper p) (CPS.writer $ unBotDeeper q)
     ],
 
   testGroup "Monad: >>=" [
-      testProperty "Lazy"        $ \m (Bot (p :: ((), SumInt))) (Bot (q :: (Int, SumInt))) ->
-          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer p >>= const (Lazy.writer q),
-      testProperty "Strict"      $ \m (Bot (p :: ((), SumInt))) (Bot (q :: (Int, SumInt))) ->
-          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer p >>= const (Strict.writer q),
-      testProperty "CPS"         $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot (Int, Bot SumInt)) ->
+      testProperty "Lazy"      $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p) >>= const (Lazy.writer (unBotDeeper q)),
+      testProperty "Strict"      $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+          isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer (unBotDeeper p) >>= const (Strict.writer (unBotDeeper q)),
+      testProperty "CPS"         $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
           isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
 
@@ -318,8 +317,8 @@ isBiStrictIn x y  =
     . shouldBeBottom (bottomX || bottomY)
 
 shouldBeBottom :: Bool -> IO o -> Property
-shouldBeBottom expectBottom result = classify expectBottom bottomLabel $ 
-  if expectBottom 
+shouldBeBottom expectBottom result = classify expectBottom bottomLabel $
+  if expectBottom
     then assertExceptionIO isBottomError result
     else ioProperty $ do
       v <- result
@@ -350,10 +349,3 @@ isBiStrictDeeperIn p q  =
       bottomQ = isBottomDeeper q
    in label (bottomLabelFor "arg1" bottomP <> ", " <> bottomLabelFor "arg2" bottomQ)
      . shouldBeBottom (bottomP || bottomQ)
-
-isStrictDeeperInWith :: Bot (a, Bot w) -> arg1 -> IO o -> Property
-isStrictDeeperInWith p x  =
-  let bottomP = isBottomDeeper p
-      bottomX = isBottom x
-   in label (bottomLabelFor "arg1" bottomP <> ", " <> bottomLabelFor "arg2" bottomX)
-     . shouldBeBottom (bottomP || bottomX)

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module WriterStrictness (test) where
+
+import           Arbitrary
 
 import           Control.Applicative
 import           Control.Arrow (first)
 import           Control.Exception (ErrorCall (..), SomeException (..),
                                     evaluate)
+import           Control.Exception.Base (displayException)
 import           Control.Monad
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
@@ -27,6 +32,7 @@ import           Data.Coerce
 import           Data.Either (fromRight)
 import           Data.Functor.Contravariant
 import           Data.Functor.Identity
+import           Data.List (isPrefixOf)
 import           Data.Maybe
 import           Data.Monoid
 
@@ -38,10 +44,13 @@ import           Test.QuickCheck.Monadic (assertExceptionIO, monadicIO, run)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Arbitrary
-
 test :: IO ()
-test = defaultMain $ testGroup "Writer" strictPairTests
+test = defaultMain $ testGroup "Writer"
+  [
+    testGroup "Pair (a, w)" strictPairTests2,
+    testGroup "Log w" strictLogTest,
+    testGroup "Pair OLD" strictPairTests
+  ]
 
 data WriterBase writer
   = WriterBase
@@ -133,6 +142,127 @@ cpsWriterLifts =
   WriterLifts
     { liftCatch = CPS.liftCatch
     }
+
+
+data WriterProp a = WriterProp
+  { lazy   :: Prop a,
+    strict :: Prop a,
+    cps    :: Prop a
+  }
+
+data Prop a = Prop a | Unsupported
+
+runWriterProps :: Testable a => String -> WriterProp a -> TestTree
+runWriterProps name WriterProp {..} =
+  testGroup name $ catMaybes [
+    runProp "Lazy" lazy,
+    runProp "Strict" strict,
+    runProp "CPS" cps
+  ]
+    where
+      runProp monadName (Prop a) = Just $ testProperty monadName a
+      runProp _ Unsupported     = Nothing
+
+strictPairTests2 :: [TestTree]
+strictPairTests2 = [
+  runWriterProps "execWriter" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Lazy.execWriterT $ Lazy.writer v,
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Strict.execWriterT $ Strict.writer v,
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ CPS.execWriterT $ CPS.writer v
+  },
+  runWriterProps "mapWriter" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.writer v,
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.writer v,
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Int, String))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer v
+  },
+  runWriterProps "listen" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.writer v,
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.writer v,
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: (Float, Sum Int))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer v
+  },
+  runWriterProps "pass" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
+        let v' = coerce v :: ((), String -> String)
+        in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.pass $ Lazy.writer (v', []),
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
+        let v' = coerce v :: ((), String -> String)
+        in isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.writer (v', []),
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: ((), F1 String String))) ->
+        let v' = coerce v :: ((), String -> String)
+        in isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer (v', [])
+  },
+  runWriterProps "censor" WriterProp {
+      lazy   = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.censor id $ Lazy.writer v,
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isStrict v $ withBaseMonad m $ Strict.runWriterT $ Strict.censor id $ Strict.writer v,
+      cps    = Prop $ \(m :: BaseMonad, Bot (v :: ((), [Int]))) -> isStrict v $ withBaseMonad m $ CPS.runWriterT $ CPS.censor id $ CPS.writer v
+  },
+
+  -- == Functor/Applicative/Monad ==
+  runWriterProps "Monad: >>=" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
+          isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer v >>= const (Lazy.writer w),
+      strict = Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
+          isStrict2 v w $ withBaseMonad m $ Strict.runWriterT $ Strict.writer v >>= const (Strict.writer w),
+      cps =    Prop $ \(m :: BaseMonad, Bot v :: (Bot ((), String)), Bot w :: (Bot (Int, String))) ->
+          isStrict2 v w $ withBaseMonad m $ CPS.runWriterT $ CPS.writer v >>= const (CPS.writer w)
+    },
+  runWriterProps "Alternative: <|>" WriterProp {
+      lazy     = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)]
+              w' = coerce w :: [(Int, String)]
+           -- same as underlying alternative 
+           in (isBottom <$> Lazy.runWriterT (Lazy.WriterT v' <|> Lazy.WriterT w')) === (isBottom <$> v' ++ w'),
+      strict   = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)]
+              w' = coerce w :: [(Int, String)]
+           in (isBottom <$> Strict.runWriterT (Strict.WriterT v' <|> Strict.WriterT w')) === (isBottom <$> v' ++ w'),
+      cps      = Prop $ \(v :: [Bot (Int, String)], w :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)]
+              w' = coerce w :: [(Int, String)]
+           in (isBottom <$> CPS.runWriterT (CPS.writerT v' <|> CPS.writerT w')) === (isBottom <$> v' ++ w')
+    },
+
+  -- == Other type classes ==
+  runWriterProps "Foldable: foldMap" WriterProp {
+      -- NOTE: foldMap is lazy in both Lazy and Strict Writers due to the use of fst to pick the value.
+      lazy   = Prop $ \(v :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)] in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Lazy.WriterT v'),
+      strict = Prop $ \(v :: [Bot (Int, String)]) ->
+          let v' = coerce v :: [(Int, String)] in isLazyValue $ getSum $ foldMap (const (Sum (0 :: Int))) (Strict.WriterT v'),
+      cps    = Unsupported
+  },
+  runWriterProps "contramap" WriterProp {
+      lazy   = Prop $ \(Bot (v :: (Int, String))) ->
+          let f = getOp $ Lazy.runWriterT $ contramap (+1) $ Lazy.WriterT (Op id) in isLazyValue $ f v,
+      strict = Prop $ \(Bot (v :: (Int, String))) ->
+          let f = getOp $ Strict.runWriterT $ contramap (+1) $ Strict.WriterT (Op id) in isStrictValue v $ f v,
+      cps    = Unsupported
+  }
+  ]
+
+strictLogTest :: [TestTree]
+strictLogTest = [
+  runWriterProps "runWriter" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.writer ((), v)),
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.writer ((), v)),
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.writer ((), v))
+  },
+  runWriterProps "mapWriter" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.mapWriterT id $ Lazy.writer (0 :: Int, v)),
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT id $ Strict.writer(0 :: Int, v)),
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT id $ CPS.writer (0 :: Int, v))
+  },
+  runWriterProps "listen" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.listen $ Lazy.writer ((), v)),
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.listen $ Strict.writer ((), v)),
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: Sum Int)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.listen $ CPS.writer ((), v))
+  },
+  runWriterProps "tell" WriterProp {
+      lazy =   Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Lazy.runWriterT $ Lazy.tell v),
+      strict = Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isLazy (withBaseMonad m $ Strict.runWriterT $ Strict.tell v),
+      cps =    Prop $ \(m :: BaseMonad, Bot (v :: String)) -> isStrict v (withBaseMonad m $ CPS.runWriterT $ CPS.tell v)
+  }
+  ]
 
 -- | Strictness tests for the value (a, w) of Writers
 --
@@ -641,7 +771,7 @@ runTestMonadStack m cont = runReaderT rd 0
 const2 :: a -> b -> c -> a
 const2 = const . const
 
-test_pair_strictness_monad :: forall k writer w (m :: k) a b. (writer w m a -> b) -> Bool -> writer w m a -> Property
+test_pair_strictness_monad :: (writer w m a -> b) -> Bool -> writer w m a -> Property
 test_pair_strictness_monad runWriter expected writer = test_pair_strictness_IOBase expected $ evaluate (runWriter writer)
 
 test_pair_strictness_IO :: (writer w IO a -> IO b) -> Bool -> writer w IO a -> Property
@@ -652,3 +782,32 @@ test_pair_strictness_IOBase True v = assertExceptionIO @ErrorCall (const True) v
 test_pair_strictness_IOBase False v = monadicIO $ run $ do
   v' <- v
   v' `seq` return ()
+
+isStrictValue :: arg1 -> a -> Property
+isStrictValue x  = isStrict x . evaluate
+
+isLazyValue :: a -> Property
+isLazyValue = isLazy . evaluate
+
+-- Strictness in one argument:
+-- The result (normalized to IO) should be bottom whenever arg1 is bottom.
+isStrict :: arg1 -> IO a -> Property
+isStrict x  = shouldBeBottom (isBottom x)
+
+-- Strictness in two arguments:
+-- The result (normalized to IO) should be bottom whenever arg1 OR arg2 is bottom.
+isStrict2 :: arg1 -> arg2 -> IO a -> Property
+isStrict2 x y  = shouldBeBottom (isBottom x || isBottom y)
+
+isLazy :: IO a -> Property
+isLazy = shouldBeBottom False
+
+shouldBeBottom :: Bool -> IO a -> Property
+shouldBeBottom True result = assertExceptionIO isBottomError result
+  where
+    -- Check error message only i.e. prefix, ignoring stacktrace.
+    isBottomError :: ErrorCall -> Bool
+    isBottomError e = "<bottom>" `isPrefixOf` displayException e
+shouldBeBottom False result = monadicIO $ run $ do
+  v <- result
+  v `seq` return ()

--- a/test/WriterStrictness.hs
+++ b/test/WriterStrictness.hs
@@ -76,7 +76,7 @@ strictnessTest = [
         let f' = unF1Bot f
             result = f' ((), mempty)
         in isStrictIn result $ withBaseMonad m $ Strict.runWriterT $ Strict.mapWriterT (f'<$>) $ pure (),
-      testProperty "CPS"    $ \m (f  :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
+      testProperty "CPS"    $ \m (f :: F1Bot ((), SumInt) ((), Bot SumInt)) ->
         let f' = coerce f :: ((), SumInt) -> ((), SumInt)
             result = f' ((), mempty)
         in isBiStrictIn result (snd result) $ withBaseMonad m $ CPS.runWriterT $ CPS.mapWriterT (f'<$>) $ pure ()
@@ -101,7 +101,7 @@ strictnessTest = [
   ],
 
   -- NOTE: strictness in the log w for censor (CPS only)
-  -- censor should be strict in the *final* value of the log w after applying the log censor (w -> w), 
+  -- censor should be strict in the *final* value of the log w after applying the log censor (w -> w),
   -- not the initial value in the given writer.
   -- Thus, for the tests below, a bottom log value is tested in the output of the log censor f, instead of the log w in the initial (a, w).
   testGroup "censor" [
@@ -127,7 +127,7 @@ strictnessTest = [
         in isStrictIn p $ withBaseMonad m $ Strict.runWriterT $ Strict.pass $ Strict.WriterT $ return p',
       testProperty "CPS"    $ \m (p :: Bot (((), F1Bot SumInt SumInt), SumInt)) ->
         let p' = coerce p :: (((), SumInt -> SumInt), SumInt)
-            result  = (snd $ fst p') mempty
+            result = (snd $ fst p') mempty
         in isBiStrictIn p result $ withBaseMonad m $ CPS.runWriterT $ CPS.pass $ CPS.writer p'
   ],
 
@@ -139,10 +139,10 @@ strictnessTest = [
     ],
 
   testGroup "Applicative: <*>" [
-      testProperty "Lazy"    $ \m(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+      testProperty "Lazy"    $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
          in isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer f' <*> Lazy.writer (unBotDeeper p),
-      testProperty "Strict"  $ \m(wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
+      testProperty "Strict"  $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
           let f' = coerce wf :: (() -> (), SumInt)
          in isBiStrictIn p wf $ withBaseMonad m $ Strict.runWriterT $ Strict.writer f' <*> Strict.writer (unBotDeeper p),
       testProperty "CPS"     $ \m (wf :: Bot (F1 () (), Bot SumInt)) (p :: Bot ((), Bot SumInt)) ->
@@ -160,11 +160,11 @@ strictnessTest = [
     ],
 
   testGroup "Monad: >>=" [
-      testProperty "Lazy"      $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+      testProperty "Lazy"    $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
           isLazy $ withBaseMonad m $ Lazy.runWriterT $ Lazy.writer (unBotDeeper p) >>= const (Lazy.writer (unBotDeeper q)),
-      testProperty "Strict"      $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+      testProperty "Strict"  $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
           isBiStrictIn p q $ withBaseMonad m $ Strict.runWriterT $ Strict.writer (unBotDeeper p) >>= const (Strict.writer (unBotDeeper q)),
-      testProperty "CPS"         $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
+      testProperty "CPS"     $ \m (p :: Bot ((), Bot SumInt)) (q :: Bot ((), Bot SumInt)) ->
           isBiStrictDeeperIn p q $ withBaseMonad m $ CPS.runWriterT $ CPS.writer (unBotDeeper p) >>= const (CPS.writer (unBotDeeper q))
     ],
 
@@ -354,7 +354,7 @@ isStrictDeeperIn p =
     . shouldBeBottom bottomP
 
 -- Deeper strictness in two arguments:
--- The result (normalized to IO) should be bottom whenever (a, w), (a, w'), w or w' is bottom.
+-- The result (normalized to IO) should be bottom whenever (a, w), (a', w'), w or w' is bottom.
 isBiStrictDeeperIn :: Bot (a, Bot w) -> Bot (a', Bot w') -> IO o -> Property
 isBiStrictDeeperIn p q  =
   let bottomP = isBottomDeeper p

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,7 +1,9 @@
 module Main (main) where
 
 import qualified ComposeT
+import qualified WriterStrictness
 
 main :: IO ()
 main = do
   ComposeT.test
+  WriterStrictness.test

--- a/test/transformers-test.cabal
+++ b/test/transformers-test.cabal
@@ -5,6 +5,12 @@ description:
   Since test frameworks and tools also depend on transformers,
   the test needs to be a separate package from the library
   in order to avoid cyclic dependencies.
+  This is a long-standing known issue in Cabal: https://github.com/haskell/cabal/issues/1575
+
+  Other packages with workarounds: 
+  - ByteString
+  - Containers
+  - Persistent
 
 build-type: Simple
 
@@ -18,37 +24,9 @@ tested-with:
   ghc ==9.8
   mhs ==0.16
 
--- Copy of transformers package
-library
-  default-language: Haskell2010
-  build-depends: base >=4.14 && <5
-  hs-source-dirs: ..
-  exposed-modules:
-    Control.Applicative.Backwards
-    Control.Applicative.Lift
-    Control.Monad.Signatures
-    Control.Monad.Trans.Accum
-    Control.Monad.Trans.Class
-    Control.Monad.Trans.Compose
-    Control.Monad.Trans.Cont
-    Control.Monad.Trans.Except
-    Control.Monad.Trans.Identity
-    Control.Monad.Trans.Maybe
-    Control.Monad.Trans.Reader
-    Control.Monad.Trans.RWS
-    Control.Monad.Trans.RWS.CPS
-    Control.Monad.Trans.RWS.Lazy
-    Control.Monad.Trans.RWS.Strict
-    Control.Monad.Trans.Select
-    Control.Monad.Trans.State
-    Control.Monad.Trans.State.Lazy
-    Control.Monad.Trans.State.Strict
-    Control.Monad.Trans.Writer
-    Control.Monad.Trans.Writer.CPS
-    Control.Monad.Trans.Writer.Lazy
-    Control.Monad.Trans.Writer.Strict
-    Data.Functor.Constant
-    Data.Functor.Reverse
+library 
+  -- Empty placeholder library.
+  -- Cannot have a package with test-suite only.
 
 test-suite tests
   type: exitcode-stdio-1.0
@@ -60,9 +38,15 @@ test-suite tests
     ComposeT
     WriterStrictness
   build-depends:
-    base >= 4.14 && <5,
-    QuickCheck,
-    ChasingBottoms,
-    tasty,
-    tasty-quickcheck,
+    base                >= 4.14 && <5,
+
+    -- tasty, QuickCheck, and ChasingBottoms depend on transformers.
+    -- These are built with the published version of transformers.
+    QuickCheck          >= 2.17 && < 3,
+    ChasingBottoms      >= 1.3.1.17 && < 2,
+    tasty               >= 1.5.4 && < 2,
+    tasty-quickcheck    >= 0.11 && < 1,
+
+    -- These are local packages.
+    transformers,  
     transformers-test

--- a/test/transformers-test.cabal
+++ b/test/transformers-test.cabal
@@ -40,6 +40,9 @@ test-suite tests
   build-depends:
     base                >= 4.14 && <5,
 
+    -- Data.Solo is not available in older GHC versions
+    OneTuple            >= 0.4.3 && < 0.5,
+
     -- tasty, QuickCheck, and ChasingBottoms depend on transformers.
     -- These are built with the published version of transformers.
     QuickCheck          >= 2.17 && < 3,

--- a/test/transformers-test.cabal
+++ b/test/transformers-test.cabal
@@ -56,7 +56,13 @@ test-suite tests
   main-is: main.hs
   default-language: Haskell2010
   other-modules:
+    Utils
     ComposeT
+    WriterStrictness
   build-depends:
     base >= 4.14 && <5,
+    QuickCheck,
+    ChasingBottoms,
+    tasty,
+    tasty-quickcheck,
     transformers-test

--- a/test/transformers-test.cabal
+++ b/test/transformers-test.cabal
@@ -34,7 +34,7 @@ test-suite tests
   main-is: main.hs
   default-language: Haskell2010
   other-modules:
-    Utils
+    Arbitrary
     ComposeT
     WriterStrictness
   build-depends:


### PR DESCRIPTION
Issue #123 

Please note: the first commit is from #125. It looks like I can't base this PR off #125 since both branches are from my fork, so the same change will appear in this PR as well until the former is merged.

Strictness tests for Writer {Lazy|Strict|CPS}:
Perhaps needless to say, but this tests strictness only in the pair `(a, w)` of the Writers, which I understood was the main concern here.
In particular, it does not cover strictness in the log `w` of the CPS writer.

Overall, the test is split into 3 parts:
- Writer functions: `listen`, `censor`, ...
- Functor/Applicative/Monad: `fmap`, `>>=`, `<|>`, ...
- other typeclass function: Foldable, Traversable, ...

I tested primarily with `Identity` and `IO`.

While writing the tests, I noticed 2 things:
a) Lazy `traverse` isn't lazy: https://github.com/haskell/transformers/blob/4b125f8136623abb8440d29efeb9f8401a90b1b8/Control/Monad/Trans/Writer/Lazy.hs#L180-L181
b) Strict `foldMap` isn't strict since it uses `fst` like the Lazy Writer: https://github.com/haskell/transformers/blob/4b125f8136623abb8440d29efeb9f8401a90b1b8/Control/Monad/Trans/Writer/Strict.hs#L176-L177

I am assuming you have some idea of the setup already from my original draft: https://github.com/ynishiza/transformers/pull/2
Please let me know if anything is unclear.

Next steps: I'll begin working on RWS and State tests if these Writer tests look like the right direction.